### PR TITLE
added uv version of compiler.sh

### DIFF
--- a/compiler_uv.sh
+++ b/compiler_uv.sh
@@ -1,0 +1,128 @@
+#TODO add options for clean/noclean, make/nomake, cython/nocython
+#TODO include instuctions on blowing away entire package for fresh install e.g. rm -r ~/venvs/mesh/lib/python3.6/site-packages/troute/*
+#set root folder of github repo (should be named t-route)
+REPOROOT=`pwd`
+#For each build step, you can set these to true to make it build
+#or set it to anything else (or unset) to skip that step
+build_mc_kernel=true
+build_diffusive_tulane_kernel=true
+build_reservoir_kernel=true
+build_framework=true
+build_routing=true
+build_config=true
+build_nwm=true
+
+if [ -z "$F90" ]
+then
+    export F90="gfortran"
+    echo "using F90=${F90}"
+fi
+if [ -z "$CC" ]
+then
+    export CC="gcc"
+    echo "using CC=${CC}"
+fi
+
+#preserve old/default behavior of installing packages with -e
+WITH_EDITABLE=true
+if [ "$1" == 'no-e' ]
+then
+WITH_EDITABLE=false
+fi
+
+#if you have custom static library paths, uncomment below and export them
+#export LIBRARY_PATH=<paths>:$LIBRARY_PATH
+#if you have custom dynamic library paths, uncomment below and export them
+#export LD_LIBRARY_PATHS=<paths>:$LD_LIBRARY_PATHS
+if [ -z "$NETCDF" ]
+then
+    export NETCDFINC=/usr/include/openmpi-x86_64/
+    # set alternative NETCDF variable include path, for example for WSL
+    # (Windows Subsystems for Linux).
+    #
+    # EXAMPLE USAGE: export NETCDFALTERNATIVE=$HOME/.conda/envs/py39/include/
+    # (before ./compiler.sh)
+    if [ -n "$NETCDFALTERNATIVE" ]
+    then
+	echo "using alternative NETCDF inc ${NETCDFALTERNATIVE}"
+	export NETCDFINC=$NETCDFALTERNATIVE
+    fi
+else
+    export NETCDFINC="${NETCDF}"
+fi
+echo "using NETCDFINC=${NETCDFINC}"
+
+if  [[ "$build_mc_kernel" == true ]]; then
+  #building reach and resevoir kernel files .o
+  cd $REPOROOT/src/kernel/muskingum/
+  make clean
+  make  || exit
+  make install || exit
+fi
+
+if  [[ "$build_diffusive_tulane_kernel" == true ]]; then
+  #building reach and resevoir kernel files .o  
+  cd $REPOROOT/src/kernel/diffusive/
+  make clean
+  make diffusive.o
+  make pydiffusive.o
+  make chxsec_lookuptable.o
+  make pychxsec_lookuptable.o
+  make install || exit
+fi
+
+if [[ "$build_reservoir_kernel" == true ]]; then
+  cd $REPOROOT/src/kernel/reservoir/
+  make clean
+  #make NETCDFINC=`nc-config --includedir` || exit
+  #make binding_lp.a
+  #make install_lp || exit
+  make
+  make install_lp || exit
+  make install_rfc || exit
+
+fi
+
+if [[ "$build_framework" == true ]]; then
+  #creates troute package
+  cd $REPOROOT/src/troute-network
+  rm -rf build
+
+  if [[ ${WITH_EDITABLE} == true ]]; then
+    uv pip install --no-build-isolation --config-setting='--build-option=--use-cython' --editable . --config-setting='editable_mode=compat' || exit
+  else
+    uv pip install --no-build-isolation --config-setting='--build-option=--use-cython' . || exit
+  fi
+fi
+
+if [[ "$build_routing" == true ]]; then
+  #updates troute package with the execution script
+  cd $REPOROOT/src/troute-routing
+  rm -rf build
+
+  if [[ ${WITH_EDITABLE} == true ]]; then
+    uv pip install --no-build-isolation --config-setting='--build-option=--use-cython' --editable . --config-setting='editable_mode=compat' || exit
+  else
+    uv pip install --no-build-isolation --config-setting='--build-option=--use-cython' . || exit
+  fi
+fi
+
+if [[ "$build_config" == true ]]; then
+  #updates troute package with the execution script
+  cd $REPOROOT/src/troute-config
+  if [[ ${WITH_EDITABLE} == true ]]; then
+    uv pip install --editable . || exit
+  else
+    uv pip install . || exit
+  fi
+fi
+
+if [[ "$build_nwm" == true ]]; then
+  #updates troute package with the execution script
+  cd $REPOROOT/src/troute-nwm
+  if [[ ${WITH_EDITABLE} == true ]]; then
+    uv pip install --editable . || exit
+  else
+    uv pip install . || exit
+  fi
+fi

--- a/src/troute-rnr/pyproject.toml
+++ b/src/troute-rnr/pyproject.toml
@@ -19,8 +19,6 @@ dependencies = [
     "lxml==5.3.0",
     "pytest==8.3.2",
     "boto3",
-    "icefabric_manage @ git+https://github.com/NGWPC/icefabric.git#subdirectory=src/icefabric_manage",
-    "icefabric_tools @ git+https://github.com/NGWPC/icefabric.git#subdirectory=src/icefabric_tools",
 ]
 
 [build-system]


### PR DESCRIPTION
### Added:
- created a new compiler.sh script that uses uv to install packages rather than pip


Tested and verified the t-route integration test suite
```sh
 tadd.bindas@U-1S6XF6R04GI88  [v] 3.11.12  ~/.../pi6/t-route   uv_compiler ●  pytest test/troute-network
============================================================================================================== test session starts ===============================================================================================================
platform linux -- Python 3.11.12, pytest-8.3.2, pluggy-1.5.0
rootdir: /home/tadd.bindas/github/pi6/t-route
configfile: pyproject.toml
plugins: anyio-4.9.0
collected 1 item                                                                                                                                                                                                                                 

test/troute-network/test_hyfeatures_network.py .                                                                                                                                                                                           [100%]

================================================================================================================ warnings summary ================================================================================================================
src/troute-rnr/.venv/lib/python3.11/site-packages/geopandas/_compat.py:7
  /home/tadd.bindas/github/pi6/t-route/src/troute-rnr/.venv/lib/python3.11/site-packages/geopandas/_compat.py:7: DeprecationWarning: The 'shapely.geos' module is deprecated, and will be removed in a future version. All attributes of 'shapely.geos' are available directly from the top-level 'shapely' namespace (since shapely 2.0.0).
    import shapely.geos

test/troute-network/test_hyfeatures_network.py::test_network
  /home/tadd.bindas/github/pi6/t-route/src/troute-nwm/src/nwm_routing/input.py:45: PydanticDeprecatedSince20: The `dict` method is deprecated; use `model_dump` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/
    config_dict = troute_configuration.dict()

test/troute-network/test_hyfeatures_network.py::test_network
  /home/tadd.bindas/github/pi6/t-route/src/troute-rnr/.venv/lib/python3.11/site-packages/pydantic/main.py:463: UserWarning: Pydantic serializer warnings:
    PydanticSerializationUnexpectedValue(Expected `PreprocessingParameters` - serialized value may not be as expected [input_value={}, input_type=dict])
    PydanticSerializationUnexpectedValue(Expected `OutputParameters` - serialized value may not be as expected [input_value={}, input_type=dict])
    return self.__pydantic_serializer__.to_python(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================================================= 1 passed, 3 warnings in 1.84s ==========================================================================================================
 tadd.bindas@U-1S6XF6R04GI88  [v] 3.11.12  ~/.../pi6/t-route   uv_compiler ●  pytest test/troute-nwm
============================================================================================================== test session starts ===============================================================================================================
platform linux -- Python 3.11.12, pytest-8.3.2, pluggy-1.5.0
rootdir: /home/tadd.bindas/github/pi6/t-route
configfile: pyproject.toml
plugins: anyio-4.9.0
collected 2 items                                                                                                                                                                                                                                

test/troute-nwm/test_nwm_route.py .                                                                                                                                                                                                        [ 50%]
test/troute-nwm/test_preprocess.py .                                                                                                                                                                                                       [100%]

================================================================================================================ warnings summary ================================================================================================================
src/troute-rnr/.venv/lib/python3.11/site-packages/geopandas/_compat.py:7
  /home/tadd.bindas/github/pi6/t-route/src/troute-rnr/.venv/lib/python3.11/site-packages/geopandas/_compat.py:7: DeprecationWarning: The 'shapely.geos' module is deprecated, and will be removed in a future version. All attributes of 'shapely.geos' are available directly from the top-level 'shapely' namespace (since shapely 2.0.0).
    import shapely.geos

test/troute-nwm/test_nwm_route.py::test_nwm_route_execution
test/troute-nwm/test_preprocess.py::test_nhd_preprocess
  /home/tadd.bindas/github/pi6/t-route/src/troute-network/troute/nhd_network_utilities_v02.py:100: DeprecationWarning: Call to deprecated function (or staticmethod) extract_waterbody_connections. (Functionality moved to Network classes) -- Deprecated since version 2.4.0.
    wbodies = nhd_network.extract_waterbody_connections(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================================================= 2 passed, 3 warnings in 7.84s ==========================================================================================================
^[[A tadd.bindas@U-1S6XF6R04GI88  [v] 3.11.12  ~/.../pi6/t-route   uv_compiler ●  pytest test/troute-routing
============================================================================================================== test session starts ===============================================================================================================
platform linux -- Python 3.11.12, pytest-8.3.2, pluggy-1.5.0
rootdir: /home/tadd.bindas/github/pi6/t-route
configfile: pyproject.toml
plugins: anyio-4.9.0
collected 5 items                                                                                                                                                                                                                                

test/troute-routing/test_hyfeature_utils.py ..                                                                                                                                                                                             [ 40%]
test/troute-routing/test_nnu_utils.py ...                                                                                                                                                                                                  [100%]

================================================================================================================ warnings summary ================================================================================================================
src/troute-rnr/.venv/lib/python3.11/site-packages/geopandas/_compat.py:7
  /home/tadd.bindas/github/pi6/t-route/src/troute-rnr/.venv/lib/python3.11/site-packages/geopandas/_compat.py:7: DeprecationWarning: The 'shapely.geos' module is deprecated, and will be removed in a future version. All attributes of 'shapely.geos' are available directly from the top-level 'shapely' namespace (since shapely 2.0.0).
    import shapely.geos

test/troute-routing/test_hyfeature_utils.py::test_build_forcing_sets
test/troute-routing/test_hyfeature_utils.py::test_assemble_forcings
  /home/tadd.bindas/github/pi6/t-route/src/troute-nwm/src/nwm_routing/input.py:45: PydanticDeprecatedSince20: The `dict` method is deprecated; use `model_dump` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/
    config_dict = troute_configuration.dict()

test/troute-routing/test_hyfeature_utils.py::test_build_forcing_sets
test/troute-routing/test_hyfeature_utils.py::test_assemble_forcings
  /home/tadd.bindas/github/pi6/t-route/src/troute-rnr/.venv/lib/python3.11/site-packages/pydantic/main.py:463: UserWarning: Pydantic serializer warnings:
    PydanticSerializationUnexpectedValue(Expected `PreprocessingParameters` - serialized value may not be as expected [input_value={}, input_type=dict])
    PydanticSerializationUnexpectedValue(Expected `OutputParameters` - serialized value may not be as expected [input_value={}, input_type=dict])
    return self.__pydantic_serializer__.to_python(

test/troute-routing/test_nnu_utils.py::test_build_nhd_forcing_sets
test/troute-routing/test_nnu_utils.py::test_da_sets
  /home/tadd.bindas/github/pi6/t-route/src/troute-network/troute/nhd_network_utilities_v02.py:100: DeprecationWarning: Call to deprecated function (or staticmethod) extract_waterbody_connections. (Functionality moved to Network classes) -- Deprecated since version 2.4.0.
    wbodies = nhd_network.extract_waterbody_connections(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================================================= 5 passed, 7 warnings in 2.44s ==========================================================================================================
```