### PR TITLE
Cnovinger ngwpc 7369 lake output var one netcdf

### DIFF
--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -2053,15 +2053,6 @@ def write_waterbody_netcdf(
                 }
             )
 
-def combine_lakeouts_to_single_netcdf(
-    wbdy_filepath, 
-    combined_name
-):
-    netcDF_path = str(wbdy_filepath) + '/*LAKEOUT.nc'
-    ds = xr.open_mfdataset(netcDF_path,combine = 'nested', concat_dim="time")
-    combined_file = str(wbdy_filepath) + '/' + combined_name + '.nc'
-    ds.to_netcdf(combined_file)
-
 def write_single_waterbody_netcdf(
     wbdy_filepath, 
     i_df,

--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -845,8 +845,7 @@ def read_netcdfs(paths, dim, transform_func=None):
 
     datasets = [process_one_path(p) for p in paths]
     combined = xr.concat(datasets, dim, combine_attrs = "override")
-    return combined
-    
+    return combined    
 
 
 def preprocess_time_station_index(xd):
@@ -2003,7 +2002,7 @@ def write_waterbody_netcdf(
                     varname = "outflow",
                     datatype = "f4",
                     dimensions = ("feature_id"),
-                    fill_value = -999900 #np.nan
+                    fill_value = np.nan
                 )
             outflow[:] = q_df.q.tolist()
             f['outflow'].setncatts(
@@ -2303,7 +2302,6 @@ def write_single_waterbody_netcdf(
                     'proj4': '+proj=lcc +units=m +a=6370000.0 +b=6370000.0 +lat_1=30.0 +lat_2=60.0 +lat_0=40.0 +lon_0=-97.0 +x_0=0 +y_0=0 +k_0=1.0 +nadgrids=@',
                     'model_initialization_time': t0.strftime('%Y-%m-%d_%H:%M:%S'),
                     'station_dimension': 'lake_id',
-                    'model_output_valid_time': wbdy_time[0].strftime('%Y-%m-%d_%H:%M:%S'),
                     'model_total_valid_times': nts,
                     'Conventions': 'CF-1.6',
                     'code_version': '',

--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -2003,7 +2003,7 @@ def write_waterbody_netcdf(
                     varname = "outflow",
                     datatype = "f4",
                     dimensions = ("feature_id"),
-                    fill_value = np.nan
+                    fill_value = -999900 #np.nan
                 )
             outflow[:] = q_df.q.tolist()
             f['outflow'].setncatts(
@@ -2057,21 +2057,8 @@ def combine_lakeouts_to_single_netcdf(
     wbdy_filepath, 
     combined_name
 ):
-    
-    '''
-    Combines all the LAKEOUT netCDF files into a single netCDF file
-        
-    Arguments
-    -------------
-        wbdy_filepath (Path or string) - directory where the LAKEOUT netcdf files are present
-        combined_name (string) - name of the combined netcdf file
-        
-    Returns
-    -------------
-    '''
-    
-    netcDF_path = str(wbdy_filepath) + '/2014*.nc'
-    ds = xr.open_mfdataset(netcDF_path,combine = 'by_coords', concat_dim="time")
+    netcDF_path = str(wbdy_filepath) + '/*LAKEOUT.nc'
+    ds = xr.open_mfdataset(netcDF_path,combine = 'nested', concat_dim="time")
     combined_file = str(wbdy_filepath) + '/' + combined_name + '.nc'
     ds.to_netcdf(combined_file)
 
@@ -2089,11 +2076,12 @@ def write_single_waterbody_netcdf(
 ):
    
     # array of simulation time
-    wbdy_time = np.array([t0 + timedelta(seconds = (time_index[i] + 1) * dt) for i in range(2)]) #time_index
+    wbdy_time = np.array([t0 + timedelta(seconds = (time_index[i] + 1) * dt) for i in range(len(time_index))]) #time_index
     
-    max_i_vals = i_df.max().to_numpy()
-    max_q_vals = q_df.max().to_numpy()
-    max_d_vals = d_df.max().to_numpy()
+    #get the max of all the values for each timestep and store them in a list. 
+    max_i_vals = i_df.max().to_numpy().tolist()
+    max_q_vals = q_df.max().to_numpy().tolist()
+    max_d_vals = d_df.max().to_numpy().tolist()
 
     if wbdy_filepath:
 
@@ -2105,11 +2093,11 @@ def write_single_waterbody_netcdf(
         waterbody_types_df = waterbody_types_df.sort_index()
         wbdy_type = waterbody_types_df.reservoir_type.to_numpy(dtype = 'int32')
 
-        num_files = 2 #i_df.shape[1]
+        num_files = i_df.shape[1]
 
         # open netCDF4 Dataset in write mode
         with netCDF4.Dataset(
-            filename = str(wbdy_filepath) + '/' + '_combined.LAKEOUT.nc',
+            filename = str(wbdy_filepath) + '/' + '_single.nc',
             mode = 'w',
             format = "NETCDF4"
         ) as f:
@@ -2190,7 +2178,7 @@ def write_single_waterbody_netcdf(
             LATITUDE = f.createVariable(
                 varname = "latitude",
                 datatype = 'f4',
-                dimensions = ("feature_id",),
+                dimensions = ("latitude",),
                 fill_value = np.nan
             )
             LATITUDE[:] = waterbodies_df.lat.tolist()
@@ -2206,7 +2194,7 @@ def write_single_waterbody_netcdf(
             LONGITUDE = f.createVariable(
                 varname = "longitude",
                 datatype = 'f4',
-                dimensions = ("feature_id",),
+                dimensions = ("longitude",),
                 fill_value = np.nan
             )
             LONGITUDE[:] = waterbodies_df.lon.tolist()
@@ -2260,7 +2248,7 @@ def write_single_waterbody_netcdf(
             inflow = f.createVariable(
                     varname = "inflow",
                     datatype = "f4",
-                    dimensions = ("feature_id",),
+                    dimensions = ("time","latitude","longitude","feature_id"),
                     fill_value = -999900
                 )
 
@@ -2282,8 +2270,8 @@ def write_single_waterbody_netcdf(
             outflow = f.createVariable(
                     varname = "outflow",
                     datatype = "f4",
-                    dimensions = ("feature_id",),
-                    fill_value = np.nan
+                    dimensions = ("time","latitude","longitude","feature_id"),
+                    fill_value = -999900 #np.nan
                 )
             outflow[:] = max_q_vals
             f['outflow'].setncatts(
@@ -2303,7 +2291,7 @@ def write_single_waterbody_netcdf(
             depth = f.createVariable(
                     varname = "water_sfc_elev",
                     datatype = "f4",
-                    dimensions = ("feature_id",),
+                    dimensions = ("time","latitude","longitude","feature_id"),
                     fill_value = np.nan
                 )
             depth[:] = max_d_vals
@@ -2313,6 +2301,23 @@ def write_single_waterbody_netcdf(
                     'units': 'm',
                     'comment': 'If reservoir_type = 4, water_sfc_elev is invalid because this value corresponds only to level pool',
                     'coordinates': 'latitude longitude'
+                }
+            )
+
+            # =========== GLOBAL ATTRIBUTES ===============  
+            f.setncatts(
+                {
+                    'TITLE': 'OUTPUT FROM T-ROUTE',
+                    'featureType': 'timeSeries',
+                    'proj4': '+proj=lcc +units=m +a=6370000.0 +b=6370000.0 +lat_1=30.0 +lat_2=60.0 +lat_0=40.0 +lon_0=-97.0 +x_0=0 +y_0=0 +k_0=1.0 +nadgrids=@',
+                    'model_initialization_time': t0.strftime('%Y-%m-%d_%H:%M:%S'),
+                    'station_dimension': 'lake_id',
+                    'model_output_valid_time': wbdy_time[0].strftime('%Y-%m-%d_%H:%M:%S'),
+                    'model_total_valid_times': nts,
+                    'Conventions': 'CF-1.6',
+                    'code_version': '',
+                    'model_output_type': 'reservoir',
+                    'model_configuration': ''
                 }
             )
 

--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -846,6 +846,7 @@ def read_netcdfs(paths, dim, transform_func=None):
     datasets = [process_one_path(p) for p in paths]
     combined = xr.concat(datasets, dim, combine_attrs = "override")
     return combined
+    
 
 
 def preprocess_time_station_index(xd):
@@ -2052,6 +2053,268 @@ def write_waterbody_netcdf(
                 }
             )
 
+def combine_lakeouts_to_single_netcdf(
+    wbdy_filepath, 
+    combined_name
+):
+    
+    '''
+    Combines all the LAKEOUT netCDF files into a single netCDF file
+        
+    Arguments
+    -------------
+        wbdy_filepath (Path or string) - directory where the LAKEOUT netcdf files are present
+        combined_name (string) - name of the combined netcdf file
+        
+    Returns
+    -------------
+    '''
+    
+    netcDF_path = str(wbdy_filepath) + '/2014*.nc'
+    ds = xr.open_mfdataset(netcDF_path,combine = 'by_coords', concat_dim="time")
+    combined_file = str(wbdy_filepath) + '/' + combined_name + '.nc'
+    ds.to_netcdf(combined_file)
+
+def write_single_waterbody_netcdf(
+    wbdy_filepath, 
+    i_df,
+    q_df,
+    d_df,
+    waterbodies_df,
+    waterbody_types_df,
+    t0, 
+    dt, 
+    nts,
+    time_index
+):
+   
+    # array of simulation time
+    wbdy_time = np.array([t0 + timedelta(seconds = (time_index[i] + 1) * dt) for i in range(2)]) #time_index
+    
+    max_i_vals = i_df.max().to_numpy()
+    max_q_vals = q_df.max().to_numpy()
+    max_d_vals = d_df.max().to_numpy()
+
+    if wbdy_filepath:
+
+        # array of segment linkIDs at gage locations. Results from these segments will be written
+        waterbodies_df = waterbodies_df[['lat','lon','crs']].sort_index()
+        wbdy_feature_id = waterbodies_df.index.to_numpy(dtype = "int64")
+
+        # dataframe of waterbody types
+        waterbody_types_df = waterbody_types_df.sort_index()
+        wbdy_type = waterbody_types_df.reservoir_type.to_numpy(dtype = 'int32')
+
+        num_files = 2 #i_df.shape[1]
+
+        # open netCDF4 Dataset in write mode
+        with netCDF4.Dataset(
+            filename = str(wbdy_filepath) + '/' + '_combined.LAKEOUT.nc',
+            mode = 'w',
+            format = "NETCDF4"
+        ) as f:
+
+            # =========== DIMENSIONS ===============
+            _ = f.createDimension("time", num_files)
+            _ = f.createDimension("feature_id", len(wbdy_feature_id))
+            _ = f.createDimension("reference_time", 1)
+            _ = f.createDimension("latitude", len(wbdy_feature_id))
+            _ = f.createDimension("longitude", len(wbdy_feature_id))
+
+            # =========== time VARIABLE ===============
+            TIME = f.createVariable(
+                varname = "time",
+                datatype = 'int32',
+                dimensions = ("time",),
+            )
+            TIME[:] = date2num(
+                wbdy_time, 
+                units = "minutes since 1970-01-01 00:00:00 UTC",
+                calendar = "gregorian"
+            )
+            f['time'].setncatts(
+                {
+                    'long_name': 'valid output time',
+                    'standard_name': 'time',
+                    'valid_min': date2num(
+                        t0, 
+                        units = "minutes since 1970-01-01 00:00:00 UTC",
+                        calendar = "gregorian"
+                    ),
+                    'valid_max': date2num(
+                        wbdy_time[num_files-1], 
+                        units = "minutes since 1970-01-01 00:00:00 UTC",
+                        calendar = "gregorian"
+                    ),
+                    'units': 'minutes since 1970-01-01T00:00:00+00:00',
+                    'calendar': 'proleptic_gregorian'
+                }
+            )
+
+            # =========== reference_time VARIABLE ===============
+            REF_TIME = f.createVariable(
+                varname = "reference_time",
+                datatype = 'int32',
+                dimensions = ("reference_time",),
+            )
+            REF_TIME[:] = date2num(
+                t0, 
+                units = "minutes since 1970-01-01 00:00:00 UTC",
+                calendar = "gregorian"
+            )
+            f['reference_time'].setncatts(
+                {
+                    'long_name': 'model initialization time',
+                    'standard_name': 'forecast_reference_time',
+                    'units': 'minutes since 1970-01-01T00:00:00+00:00',
+                    'calendar': 'proleptic_gregorian'
+                }
+            )
+
+            # =========== feature_id VARIABLE ===============
+            FEATURE_ID = f.createVariable(
+                varname = "feature_id",
+                datatype = 'int64',
+                dimensions = ("feature_id",),
+            )
+            FEATURE_ID[:] = wbdy_feature_id
+            f['feature_id'].setncatts(
+                {
+                    'long_name': 'Lake ComID',
+                    'comment': '',
+                    'cf_role:': 'timeseries_id'
+                }
+            )
+
+            # =========== latitude VARIABLE ===============
+            LATITUDE = f.createVariable(
+                varname = "latitude",
+                datatype = 'f4',
+                dimensions = ("feature_id",),
+                fill_value = np.nan
+            )
+            LATITUDE[:] = waterbodies_df.lat.tolist()
+            f['latitude'].setncatts(
+                {
+                    'long_name': 'Lake latitude',
+                    'standard_name': 'latitude',
+                    'units': 'degrees_north'
+                }
+            )
+            
+            # =========== longitude VARIABLE ===============
+            LONGITUDE = f.createVariable(
+                varname = "longitude",
+                datatype = 'f4',
+                dimensions = ("feature_id",),
+                fill_value = np.nan
+            )
+            LONGITUDE[:] = waterbodies_df.lon.tolist()
+            f['longitude'].setncatts(
+                {
+                    'long_name': 'Lake longitude',
+                    'standard_name': 'longitude',
+                    'units': 'degrees_east'
+                }
+            )
+            
+            # =========== reservoir type VARIABLE ===============            
+            res_type = f.createVariable(
+                    varname = "reservoir_type",
+                    datatype = "i4",
+                    dimensions = ("feature_id")
+                )
+            res_type[:] = wbdy_type
+            f['reservoir_type'].setncatts(
+                {
+                    'coordinates': 'latitude longitude',
+                    'long_name': 'reservoir_type',
+                    'flag_values': [1, 2, 3, 4],
+                    'flag_meanings': 'Level_pool USGS-persistence USACE-persistence RFC-forecasts'
+                }
+            )
+            
+            # =========== crs VARIABLE ===============            
+            crs = f.createVariable(
+                    varname = "crs",
+                    datatype = "S1",
+                    dimensions = ()
+                )
+            crs[:] = np.array(waterbodies_df['crs'].iat[0],dtype = '|S1')
+            f['crs'].setncatts(
+                {
+                    'transform_name': 'latitude longitude',
+                    'grid_mapping_name': 'latitude longitude',
+                    'esri_pe_string': 'GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]];-400 -400 1000000000;-100000 10000;-100000 10000;8.98315284119521E-09;0.001;0.001;IsHighPrecision',
+                    'spatial_ref': 'GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]];-400 -400 1000000000;-100000 10000;-100000 10000;8.98315284119521E-09;0.001;0.001;IsHighPrecision',
+                    'long_name': 'CRS definition',
+                    'longitude_of_prime_meridian': 0.0,
+                    '_CoordinateAxes': 'latitude longitude',
+                    'semi_major_axis': 6378137.0,
+                    'semi_minor_axis': 6356752.5,
+                    'inverse_flattening': 298.25723
+                }
+            )
+            
+            # =========== inflow VARIABLE ===============            
+            inflow = f.createVariable(
+                    varname = "inflow",
+                    datatype = "f4",
+                    dimensions = ("feature_id",),
+                    fill_value = -999900
+                )
+
+            inflow[:] = max_i_vals
+            f['inflow'].setncatts(
+                {
+                    'long_name': 'Lake Inflow',
+                    'units': 'm3 s-1',
+                    'grid_mapping': 'crs',
+                    'valid_range': [-1000000,1000000],
+                    'coordinates': 'latitude longitude',
+                    'add_offset': 0.0,
+                    'scale_factor': 0.01,
+                    'missing_value': -999900
+                }
+            )
+
+            # =========== outflow VARIABLE ===============            
+            outflow = f.createVariable(
+                    varname = "outflow",
+                    datatype = "f4",
+                    dimensions = ("feature_id",),
+                    fill_value = np.nan
+                )
+            outflow[:] = max_q_vals
+            f['outflow'].setncatts(
+                {
+                    'long_name': 'Lake Outflow',
+                    'units': 'm3 s-1',
+                    'grid_mapping': 'crs',
+                    'valid_range': [-1000000,1000000],
+                    'coordinates': 'latitude longitude',
+                    'add_offset': 0.0,
+                    'scale_factor': 0.01,
+                    'missing_value': -999900
+                }
+            )
+
+            # =========== depth VARIABLE ===============            
+            depth = f.createVariable(
+                    varname = "water_sfc_elev",
+                    datatype = "f4",
+                    dimensions = ("feature_id",),
+                    fill_value = np.nan
+                )
+            depth[:] = max_d_vals
+            f['water_sfc_elev'].setncatts(
+                {
+                    'long_name': 'Water Surface Elevation',
+                    'units': 'm',
+                    'comment': 'If reservoir_type = 4, water_sfc_elev is invalid because this value corresponds only to level pool',
+                    'coordinates': 'latitude longitude'
+                }
+            )
 
 def write_flowveldepth_csv_pkl(stream_output_directory, file_name,
                               flow, velocity, depth, nudge_df, timestamps,

--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -2087,7 +2087,7 @@ def write_single_waterbody_netcdf(
 
         # open netCDF4 Dataset in write mode
         with netCDF4.Dataset(
-            filename = str(wbdy_filepath) + '/' + '_single.nc',
+            filename = str(wbdy_filepath) + '/' + str(wbdy_feature_id) + '.LAKEOUT.nc',
             mode = 'w',
             format = "NETCDF4"
         ) as f:

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -327,7 +327,11 @@ def nwm_output_generator(
         num_files = i_df.shape[1]
         LOG.info("Output of "+str(num_files)+" waterbody files to be written to folder: "+str(Path(wbdyo).resolve()))     
         start = time.time()
-        for i in range(i_df.shape[1]):              
+        LOG.info("Range = " + str(range(i_df.shape[1])))
+        LOG.info(list(i_df.columns))
+        
+        #for i in range(i_df.shape[1]):              
+        for i in range(2):              
             nhd_io.write_waterbody_netcdf(
                 wbdyo, 
                 i_df.iloc[:,[i]],
@@ -338,8 +342,30 @@ def nwm_output_generator(
                 t0, 
                 dt, 
                 nts,
-                time_index[i],
+                time_index[i]
             )
+
+        try:    
+            nhd_io.write_single_waterbody_netcdf(
+                wbdyo, 
+                i_df,
+                q_df,
+                d_df,
+                output_waterbodies_df,
+                output_waterbody_types_df,
+                t0, 
+                dt, 
+                nts,
+                time_index
+            )
+        except Exception as e:
+            print("Error in writing to single netcdf: " + str(e))
+        
+        try:
+            nhd_io.combine_lakeouts_to_single_netcdf(wbdyo,'_combined_lakeout')
+        except Exception as e:
+            print("Error in combining lakeout netcdf: " + str(e))
+
         LOG.info("Output of "+str(num_files)+" waterbody files written to folder: "+str(Path(wbdyo).resolve()))     
         LOG.debug("writing LAKEOUT files took a total time of %s seconds." % (time.time() - start))
     elif wbdyo:

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -325,26 +325,25 @@ def nwm_output_generator(
             output_waterbodies_df = waterbodies_df
             output_waterbody_types_df = waterbody_types_df
         num_files = i_df.shape[1]
-        LOG.info("Output of "+str(num_files)+" waterbody files to be written to folder: "+str(Path(wbdyo).resolve()))     
+        LOG.info("Single NetCDF Output of "+str(num_files)+" timesteps to be written to folder: "+str(Path(wbdyo).resolve()))     
         start = time.time()
-        LOG.info("Range = " + str(range(i_df.shape[1])))
-        LOG.info(list(i_df.columns))
-        
-        for i in range(i_df.shape[1]):              
-            nhd_io.write_waterbody_netcdf(
-                wbdyo, 
-                i_df.iloc[:,[i]],
-                q_df.iloc[:,[i]],
-                d_df.iloc[:,[i]],
-                output_waterbodies_df,
-                output_waterbody_types_df,
-                t0, 
-                dt, 
-                nts,
-                time_index[i]
-            )
+
+        #Suppress the following function call if you don't need individual timestep netcdfs.
+        #This function can potentially be useful for debugging.
+        # for i in range(i_df.shape[1]):              
+        #     nhd_io.write_waterbody_netcdf(
+        #         wbdyo, 
+        #         i_df.iloc[:,[i]],
+        #         q_df.iloc[:,[i]],
+        #         d_df.iloc[:,[i]],
+        #         output_waterbodies_df,
+        #         output_waterbody_types_df,
+        #         t0, 
+        #         dt, 
+        #         nts,
+        #         time_index[i]
+        #     )
  
-           
         nhd_io.write_single_waterbody_netcdf(
             wbdyo, 
             i_df,
@@ -358,7 +357,7 @@ def nwm_output_generator(
             time_index
         )
 
-        LOG.info("Output of "+str(num_files)+" waterbody files written to folder: "+str(Path(wbdyo).resolve()))     
+        LOG.info("Single NetCDF Output of "+str(num_files)+" timesteps written to folder: "+str(Path(wbdyo).resolve()))     
         LOG.debug("writing LAKEOUT files took a total time of %s seconds." % (time.time() - start))
     elif wbdyo:
         LOG.warning("Requested LAKEOUT files not written. waterbodies_df is empty. Verify gage basin has a waterbody.")

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -358,8 +358,6 @@ def nwm_output_generator(
             time_index
         )
 
-        nhd_io.combine_lakeouts_to_single_netcdf(wbdyo,'__combined_lakeout')
-        
         LOG.info("Output of "+str(num_files)+" waterbody files written to folder: "+str(Path(wbdyo).resolve()))     
         LOG.debug("writing LAKEOUT files took a total time of %s seconds." % (time.time() - start))
     elif wbdyo:

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -329,7 +329,7 @@ def nwm_output_generator(
         start = time.time()
 
         #Suppress the following function call if you don't need individual timestep netcdfs.
-        #This function can potentially be useful for debugging.
+        #This function can potentially be useful for debugging. So left it here and in nhd_io.py
         # for i in range(i_df.shape[1]):              
         #     nhd_io.write_waterbody_netcdf(
         #         wbdyo, 

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -330,8 +330,7 @@ def nwm_output_generator(
         LOG.info("Range = " + str(range(i_df.shape[1])))
         LOG.info(list(i_df.columns))
         
-        #for i in range(i_df.shape[1]):              
-        for i in range(2):              
+        for i in range(i_df.shape[1]):              
             nhd_io.write_waterbody_netcdf(
                 wbdyo, 
                 i_df.iloc[:,[i]],
@@ -344,28 +343,23 @@ def nwm_output_generator(
                 nts,
                 time_index[i]
             )
+ 
+           
+        nhd_io.write_single_waterbody_netcdf(
+            wbdyo, 
+            i_df,
+            q_df,
+            d_df,
+            output_waterbodies_df,
+            output_waterbody_types_df,
+            t0, 
+            dt, 
+            nts,
+            time_index
+        )
 
-        try:    
-            nhd_io.write_single_waterbody_netcdf(
-                wbdyo, 
-                i_df,
-                q_df,
-                d_df,
-                output_waterbodies_df,
-                output_waterbody_types_df,
-                t0, 
-                dt, 
-                nts,
-                time_index
-            )
-        except Exception as e:
-            print("Error in writing to single netcdf: " + str(e))
+        nhd_io.combine_lakeouts_to_single_netcdf(wbdyo,'__combined_lakeout')
         
-        try:
-            nhd_io.combine_lakeouts_to_single_netcdf(wbdyo,'_combined_lakeout')
-        except Exception as e:
-            print("Error in combining lakeout netcdf: " + str(e))
-
         LOG.info("Output of "+str(num_files)+" waterbody files written to folder: "+str(Path(wbdyo).resolve()))     
         LOG.debug("writing LAKEOUT files took a total time of %s seconds." % (time.time() - start))
     elif wbdyo:


### PR DESCRIPTION
This pull request implements a function to generate a single LAKEOUT netcdf in the t-route reservoir modeling routine.

## Additions

-

## Removals

-

## Changes

- troute-network/troute/nhd_io.py
- troute-nwm/src/nwm-routing/output.py

## Testing

1.

## Screenshots


## Notes

- Updated nhd_io.py with a new function that outputs a single LAKEOUT netcdf file combining all the timesteps into one.
- Updated output.py from where the function in nhd_io.py is called.
- The previous function thta produces netcdf per timestep is retained in the code. It might be a useful tool for debugging purposes. 

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
