### PR TITLE
Create lakeout netCDF file whenever the lakeout_output parameter is specified in the t-route config yaml file (NGWPC-8377)

### DIFF
--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -2064,7 +2064,7 @@ def write_single_waterbody_netcdf(
     nts,
     time_index
 ):
-   
+    netcdfname = 'troute_lakeout_' + t0.strftime('%Y%m%d%H%M') + '.nc'
 
     if not i_df.empty:
         # array of simulation time
@@ -2096,7 +2096,7 @@ def write_single_waterbody_netcdf(
 
     # open netCDF4 Dataset in write mode
     with netCDF4.Dataset(
-        filename = str(wbdy_filepath) + '/' + 'troute_lakeout.nc',
+        filename = str(wbdy_filepath) + '/' + netcdfname,
         mode = 'w',
         format = "NETCDF4"
     ) as f:

--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -2076,9 +2076,6 @@ def write_single_waterbody_netcdf(
         max_q_vals = q_df.max().to_numpy().tolist()
         max_d_vals = d_df.max().to_numpy().tolist()
 
-        wbdy_time = np.array([t0 + timedelta(seconds = (time_index[i] + 1) * dt) for i in range(len(time_index))]) #time_index
-        num_timesteps = len(wbdy_time) #for number of timesteps
-
         # array of segment linkIDs at gage locations. Results from these segments will be written
         waterbodies_df = waterbodies_df[['lat','lon','crs']].sort_index()
         wbdy_feature_id = waterbodies_df.index.to_numpy(dtype = "int64")

--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -2065,15 +2065,19 @@ def write_single_waterbody_netcdf(
     time_index
 ):
    
-    # array of simulation time
-    wbdy_time = np.array([t0 + timedelta(seconds = (time_index[i] + 1) * dt) for i in range(len(time_index))]) #time_index
-    
-    #get the max of all the values for each timestep and store them in a list. 
-    max_i_vals = i_df.max().to_numpy().tolist()
-    max_q_vals = q_df.max().to_numpy().tolist()
-    max_d_vals = d_df.max().to_numpy().tolist()
 
-    if wbdy_filepath:
+    if not i_df.empty:
+        # array of simulation time
+        wbdy_time = np.array([t0 + timedelta(seconds = (time_index[i] + 1) * dt) for i in range(len(time_index))]) #time_index
+        num_timesteps = len(wbdy_time) #for number of timesteps
+
+        #get the max of all the values for each timestep and store them in a list. 
+        max_i_vals = i_df.max().to_numpy().tolist()
+        max_q_vals = q_df.max().to_numpy().tolist()
+        max_d_vals = d_df.max().to_numpy().tolist()
+
+        wbdy_time = np.array([t0 + timedelta(seconds = (time_index[i] + 1) * dt) for i in range(len(time_index))]) #time_index
+        num_timesteps = len(wbdy_time) #for number of timesteps
 
         # array of segment linkIDs at gage locations. Results from these segments will be written
         waterbodies_df = waterbodies_df[['lat','lon','crs']].sort_index()
@@ -2082,222 +2086,255 @@ def write_single_waterbody_netcdf(
         # dataframe of waterbody types
         waterbody_types_df = waterbody_types_df.sort_index()
         wbdy_type = waterbody_types_df.reservoir_type.to_numpy(dtype = 'int32')
+    else:
+        #initialize all variables
+        max_i_vals = np.array([0], dtype="int32") #single value array of length 1.
+        max_q_vals = np.array([0], dtype="int32")
+        max_d_vals = np.array([0], dtype="int32")
 
-        num_files = i_df.shape[1]
+        wbdy_feature_id = np.array([0], dtype="int32") 
+        wbdy_type = np.array([0], dtype="int32") 
+        wbdy_time = np.array([datetime.strptime(time_index[i], "%Y-%m-%d %H:%M:%S") for i in range(len(time_index))]) #time_index
+        num_timesteps = len(wbdy_time)
 
-        # open netCDF4 Dataset in write mode
-        with netCDF4.Dataset(
-            filename = str(wbdy_filepath) + '/' + str(wbdy_feature_id) + '.LAKEOUT.nc',
-            mode = 'w',
-            format = "NETCDF4"
-        ) as f:
+    # open netCDF4 Dataset in write mode
+    with netCDF4.Dataset(
+        filename = str(wbdy_filepath) + '/' + 'troute_lakeout.nc',
+        mode = 'w',
+        format = "NETCDF4"
+    ) as f:
 
-            # =========== DIMENSIONS ===============
-            _ = f.createDimension("time", num_files)
-            _ = f.createDimension("feature_id", len(wbdy_feature_id))
-            _ = f.createDimension("reference_time", 1)
-            _ = f.createDimension("latitude", len(wbdy_feature_id))
-            _ = f.createDimension("longitude", len(wbdy_feature_id))
+        # =========== DIMENSIONS ===============
+        _ = f.createDimension("time", num_timesteps)
+        _ = f.createDimension("feature_id", len(wbdy_feature_id))
+        _ = f.createDimension("reference_time", 1)
+        _ = f.createDimension("latitude", len(wbdy_feature_id))
+        _ = f.createDimension("longitude", len(wbdy_feature_id))
 
-            # =========== time VARIABLE ===============
-            TIME = f.createVariable(
-                varname = "time",
-                datatype = 'int32',
-                dimensions = ("time",),
-            )
-            TIME[:] = date2num(
-                wbdy_time, 
-                units = "minutes since 1970-01-01 00:00:00 UTC",
-                calendar = "gregorian"
-            )
-            f['time'].setncatts(
-                {
-                    'long_name': 'valid output time',
-                    'standard_name': 'time',
-                    'valid_min': date2num(
-                        t0, 
-                        units = "minutes since 1970-01-01 00:00:00 UTC",
-                        calendar = "gregorian"
-                    ),
-                    'valid_max': date2num(
-                        wbdy_time[num_files-1], 
-                        units = "minutes since 1970-01-01 00:00:00 UTC",
-                        calendar = "gregorian"
-                    ),
-                    'units': 'minutes since 1970-01-01T00:00:00+00:00',
-                    'calendar': 'proleptic_gregorian'
-                }
-            )
+        # =========== time VARIABLE ===============
+        TIME = f.createVariable(
+            varname = "time",
+            datatype = 'int32',
+            dimensions = ("time",),
+        )
+        TIME[:] = date2num(
+            wbdy_time, 
+            units = "minutes since 1970-01-01 00:00:00 UTC",
+            calendar = "gregorian"
+        )
+        f['time'].setncatts(
+            {
+                'long_name': 'valid output time',
+                'standard_name': 'time',
+                'valid_min': date2num(
+                    t0, 
+                    units = "minutes since 1970-01-01 00:00:00 UTC",
+                    calendar = "gregorian"
+                ),
+                'valid_max': date2num(
+                    wbdy_time[num_timesteps-1], 
+                    units = "minutes since 1970-01-01 00:00:00 UTC",
+                    calendar = "gregorian"
+                ),
+                'units': 'minutes since 1970-01-01T00:00:00+00:00',
+                'calendar': 'proleptic_gregorian'
+            }
+        )
 
-            # =========== reference_time VARIABLE ===============
-            REF_TIME = f.createVariable(
-                varname = "reference_time",
-                datatype = 'int32',
-                dimensions = ("reference_time",),
-            )
-            REF_TIME[:] = date2num(
-                t0, 
-                units = "minutes since 1970-01-01 00:00:00 UTC",
-                calendar = "gregorian"
-            )
-            f['reference_time'].setncatts(
-                {
-                    'long_name': 'model initialization time',
-                    'standard_name': 'forecast_reference_time',
-                    'units': 'minutes since 1970-01-01T00:00:00+00:00',
-                    'calendar': 'proleptic_gregorian'
-                }
-            )
+        # =========== reference_time VARIABLE ===============
+        REF_TIME = f.createVariable(
+            varname = "reference_time",
+            datatype = 'int32',
+            dimensions = ("reference_time",),
+        )
+        REF_TIME[:] = date2num(
+            t0, 
+            units = "minutes since 1970-01-01 00:00:00 UTC",
+            calendar = "gregorian"
+        )
+        f['reference_time'].setncatts(
+            {
+                'long_name': 'model initialization time',
+                'standard_name': 'forecast_reference_time',
+                'units': 'minutes since 1970-01-01T00:00:00+00:00',
+                'calendar': 'proleptic_gregorian'
+            }
+        )
 
-            # =========== feature_id VARIABLE ===============
-            FEATURE_ID = f.createVariable(
-                varname = "feature_id",
-                datatype = 'int64',
-                dimensions = ("feature_id",),
-            )
-            FEATURE_ID[:] = wbdy_feature_id
-            f['feature_id'].setncatts(
-                {
-                    'long_name': 'Lake ComID',
-                    'comment': '',
-                    'cf_role:': 'timeseries_id'
-                }
-            )
+        # =========== feature_id VARIABLE ===============
+        FEATURE_ID = f.createVariable(
+            varname = "feature_id",
+            datatype = 'int64',
+            dimensions = ("feature_id",),
+        )
+        FEATURE_ID[:] = wbdy_feature_id
+        f['feature_id'].setncatts(
+            {
+                'long_name': 'Lake ComID',
+                'comment': '',
+                'cf_role:': 'timeseries_id'
+            }
+        )
 
-            # =========== latitude VARIABLE ===============
-            LATITUDE = f.createVariable(
-                varname = "latitude",
-                datatype = 'f4',
-                dimensions = ("latitude",),
-                fill_value = np.nan
-            )
+        # =========== latitude VARIABLE ===============
+        LATITUDE = f.createVariable(
+            varname = "latitude",
+            datatype = 'f4',
+            dimensions = ("latitude",),
+            fill_value = np.nan
+        )
+        if not waterbodies_df.empty:
             LATITUDE[:] = waterbodies_df.lat.tolist()
-            f['latitude'].setncatts(
-                {
-                    'long_name': 'Lake latitude',
-                    'standard_name': 'latitude',
-                    'units': 'degrees_north'
-                }
+        else:
+            LATITUDE[:] = np.nan
+        f['latitude'].setncatts(
+            {
+                'long_name': 'Lake latitude',
+                'standard_name': 'latitude',
+                'units': 'degrees_north'
+            }
+        )
+        
+        # =========== longitude VARIABLE ===============
+        LONGITUDE = f.createVariable(
+            varname = "longitude",
+            datatype = 'f4',
+            dimensions = ("longitude",),
+            fill_value = np.nan
+        )
+        if not waterbodies_df.empty:
+            LONGITUDE[:] = waterbodies_df.lon.tolist()
+        else:
+            LONGITUDE[:] = np.nan
+        f['longitude'].setncatts(
+            {
+                'long_name': 'Lake longitude',
+                'standard_name': 'longitude',
+                'units': 'degrees_east'
+            }
+        )
+        
+        # =========== reservoir type VARIABLE ===============            
+        res_type = f.createVariable(
+                varname = "reservoir_type",
+                datatype = "i4",
+                dimensions = ("feature_id")
             )
-            
-            # =========== longitude VARIABLE ===============
-            LONGITUDE = f.createVariable(
-                varname = "longitude",
-                datatype = 'f4',
-                dimensions = ("longitude",),
+        res_type[:] = wbdy_type
+        f['reservoir_type'].setncatts(
+            {
+                'coordinates': 'latitude longitude',
+                'long_name': 'reservoir_type',
+                'flag_values': [1, 2, 3, 4],
+                'flag_meanings': 'Level_pool USGS-persistence USACE-persistence RFC-forecasts'
+            }
+        )
+        
+        # =========== crs VARIABLE ===============            
+        crs = f.createVariable(
+                varname = "crs",
+                datatype = "S1",
+                dimensions = ()
+            )
+        if not waterbodies_df.empty:
+            crs[:] = np.array(waterbodies_df['crs'].iat[0],dtype = '|S1')
+        else:
+            crs[:] = np.array(['n'],dtype = '|S1')
+        f['crs'].setncatts(
+            {
+                'transform_name': 'latitude longitude',
+                'grid_mapping_name': 'latitude longitude',
+                'esri_pe_string': 'GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]];-400 -400 1000000000;-100000 10000;-100000 10000;8.98315284119521E-09;0.001;0.001;IsHighPrecision',
+                'spatial_ref': 'GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]];-400 -400 1000000000;-100000 10000;-100000 10000;8.98315284119521E-09;0.001;0.001;IsHighPrecision',
+                'long_name': 'CRS definition',
+                'longitude_of_prime_meridian': 0.0,
+                '_CoordinateAxes': 'latitude longitude',
+                'semi_major_axis': 6378137.0,
+                'semi_minor_axis': 6356752.5,
+                'inverse_flattening': 298.25723
+            }
+        )
+        
+        # =========== inflow VARIABLE ===============            
+        inflow = f.createVariable(
+                varname = "inflow",
+                datatype = "f4",
+                dimensions = ("time","latitude","longitude","feature_id"),
+                fill_value = -999900
+            )
+        inflow[:] = max_i_vals
+        f['inflow'].setncatts(
+            {
+                'long_name': 'Lake Inflow',
+                'units': 'm3 s-1',
+                'grid_mapping': 'crs',
+                'valid_range': [-1000000,1000000],
+                'coordinates': 'latitude longitude',
+                'add_offset': 0.0,
+                'scale_factor': 0.01,
+                'missing_value': -999900
+            }
+        )
+
+        # =========== outflow VARIABLE ===============            
+        outflow = f.createVariable(
+                varname = "outflow",
+                datatype = "f4",
+                dimensions = ("time","latitude","longitude","feature_id"),
+                fill_value = -999900 #np.nan
+            )
+        outflow[:] = max_q_vals
+        f['outflow'].setncatts(
+            {
+                'long_name': 'Lake Outflow',
+                'units': 'm3 s-1',
+                'grid_mapping': 'crs',
+                'valid_range': [-1000000,1000000],
+                'coordinates': 'latitude longitude',
+                'add_offset': 0.0,
+                'scale_factor': 0.01,
+                'missing_value': -999900
+            }
+        )
+
+        # =========== depth VARIABLE ===============            
+        depth = f.createVariable(
+                varname = "water_sfc_elev",
+                datatype = "f4",
+                dimensions = ("time","latitude","longitude","feature_id"),
                 fill_value = np.nan
             )
-            LONGITUDE[:] = waterbodies_df.lon.tolist()
-            f['longitude'].setncatts(
-                {
-                    'long_name': 'Lake longitude',
-                    'standard_name': 'longitude',
-                    'units': 'degrees_east'
-                }
-            )
-            
-            # =========== reservoir type VARIABLE ===============            
-            res_type = f.createVariable(
-                    varname = "reservoir_type",
-                    datatype = "i4",
-                    dimensions = ("feature_id")
-                )
-            res_type[:] = wbdy_type
-            f['reservoir_type'].setncatts(
-                {
-                    'coordinates': 'latitude longitude',
-                    'long_name': 'reservoir_type',
-                    'flag_values': [1, 2, 3, 4],
-                    'flag_meanings': 'Level_pool USGS-persistence USACE-persistence RFC-forecasts'
-                }
-            )
-            
-            # =========== crs VARIABLE ===============            
-            crs = f.createVariable(
-                    varname = "crs",
-                    datatype = "S1",
-                    dimensions = ()
-                )
-            crs[:] = np.array(waterbodies_df['crs'].iat[0],dtype = '|S1')
-            f['crs'].setncatts(
-                {
-                    'transform_name': 'latitude longitude',
-                    'grid_mapping_name': 'latitude longitude',
-                    'esri_pe_string': 'GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]];-400 -400 1000000000;-100000 10000;-100000 10000;8.98315284119521E-09;0.001;0.001;IsHighPrecision',
-                    'spatial_ref': 'GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]];-400 -400 1000000000;-100000 10000;-100000 10000;8.98315284119521E-09;0.001;0.001;IsHighPrecision',
-                    'long_name': 'CRS definition',
-                    'longitude_of_prime_meridian': 0.0,
-                    '_CoordinateAxes': 'latitude longitude',
-                    'semi_major_axis': 6378137.0,
-                    'semi_minor_axis': 6356752.5,
-                    'inverse_flattening': 298.25723
-                }
-            )
-            
-            # =========== inflow VARIABLE ===============            
-            inflow = f.createVariable(
-                    varname = "inflow",
-                    datatype = "f4",
-                    dimensions = ("time","latitude","longitude","feature_id"),
-                    fill_value = -999900
-                )
+        depth[:] = max_d_vals
+        f['water_sfc_elev'].setncatts(
+            {
+                'long_name': 'Water Surface Elevation',
+                'units': 'm',
+                'comment': 'If reservoir_type = 4, water_sfc_elev is invalid because this value corresponds only to level pool',
+                'coordinates': 'latitude longitude'
+            }
+        )
 
-            inflow[:] = max_i_vals
-            f['inflow'].setncatts(
-                {
-                    'long_name': 'Lake Inflow',
-                    'units': 'm3 s-1',
-                    'grid_mapping': 'crs',
-                    'valid_range': [-1000000,1000000],
-                    'coordinates': 'latitude longitude',
-                    'add_offset': 0.0,
-                    'scale_factor': 0.01,
-                    'missing_value': -999900
-                }
-            )
-
-            # =========== outflow VARIABLE ===============            
-            outflow = f.createVariable(
-                    varname = "outflow",
-                    datatype = "f4",
-                    dimensions = ("time","latitude","longitude","feature_id"),
-                    fill_value = -999900 #np.nan
-                )
-            outflow[:] = max_q_vals
-            f['outflow'].setncatts(
-                {
-                    'long_name': 'Lake Outflow',
-                    'units': 'm3 s-1',
-                    'grid_mapping': 'crs',
-                    'valid_range': [-1000000,1000000],
-                    'coordinates': 'latitude longitude',
-                    'add_offset': 0.0,
-                    'scale_factor': 0.01,
-                    'missing_value': -999900
-                }
-            )
-
-            # =========== depth VARIABLE ===============            
-            depth = f.createVariable(
-                    varname = "water_sfc_elev",
-                    datatype = "f4",
-                    dimensions = ("time","latitude","longitude","feature_id"),
-                    fill_value = np.nan
-                )
-            depth[:] = max_d_vals
-            f['water_sfc_elev'].setncatts(
-                {
-                    'long_name': 'Water Surface Elevation',
-                    'units': 'm',
-                    'comment': 'If reservoir_type = 4, water_sfc_elev is invalid because this value corresponds only to level pool',
-                    'coordinates': 'latitude longitude'
-                }
-            )
-
-            # =========== GLOBAL ATTRIBUTES ===============  
+        # =========== GLOBAL ATTRIBUTES =============== 
+        if not waterbodies_df.empty:
             f.setncatts(
                 {
                     'TITLE': 'OUTPUT FROM T-ROUTE',
+                    'featureType': 'timeSeries',
+                    'proj4': '+proj=lcc +units=m +a=6370000.0 +b=6370000.0 +lat_1=30.0 +lat_2=60.0 +lat_0=40.0 +lon_0=-97.0 +x_0=0 +y_0=0 +k_0=1.0 +nadgrids=@',
+                    'model_initialization_time': t0.strftime('%Y-%m-%d_%H:%M:%S'),
+                    'station_dimension': 'lake_id',
+                    'model_total_valid_times': nts,
+                    'Conventions': 'CF-1.6',
+                    'code_version': '',
+                    'model_output_type': 'reservoir',
+                    'model_configuration': ''
+                }
+            )
+        else:
+            f.setncatts(
+                {
+                    'TITLE': 'OUTPUT FROM T-ROUTE',
+                    'basin_characteristics': 'There are no waterbodies in this basin',
                     'featureType': 'timeSeries',
                     'proj4': '+proj=lcc +units=m +a=6370000.0 +b=6370000.0 +lat_1=30.0 +lat_2=60.0 +lat_0=40.0 +lon_0=-97.0 +x_0=0 +y_0=0 +k_0=1.0 +nadgrids=@',
                     'model_initialization_time': t0.strftime('%Y-%m-%d_%H:%M:%S'),

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -314,10 +314,14 @@ def nwm_output_generator(
     if test:
         flowveldepth.to_pickle(Path(test))
     
+    #dropping all data from waterbodies_df for testing. The line below should be deleted before merging.
+    #waterbodies_df = pd.DataFrame(columns=waterbodies_df.columns)
+
     if wbdyo and not waterbodies_df.empty:
         LOG.debug("Writing waterbody output.")
         
         time_index, tmp_variable = map(list,zip(*i_df.columns.tolist()))
+        LOG.info(i_df.head(5))
         if not duplicate_ids_df.empty:
             output_waterbodies_df = waterbodies_df.rename(index=dict(duplicate_ids_df[['synthetic_ids','lake_id']].values))
             output_waterbody_types_df = waterbody_types_df.rename(index=dict(duplicate_ids_df[['synthetic_ids','lake_id']].values))
@@ -356,11 +360,31 @@ def nwm_output_generator(
             nts,
             time_index
         )
-
         LOG.info("Single NetCDF Output of "+str(num_files)+" timesteps written to folder: "+str(Path(wbdyo).resolve()))     
         LOG.debug("writing LAKEOUT files took a total time of %s seconds." % (time.time() - start))
-    elif wbdyo:
-        LOG.warning("Requested LAKEOUT files not written. waterbodies_df is empty. Verify gage basin has a waterbody.")
+    elif wbdyo and waterbodies_df.empty:
+        #this portion of the code is used to create lakeout nc files with zero values.
+        df_empty = pd.DataFrame() #empty dataframes for all inputs
+
+        #use one of the nexus output files to read the timestep datetimes
+        pattern = "nex-*.csv"
+        first_nex_file = next(Path(wbdyo).glob(pattern))
+        df = pd.read_csv(first_nex_file)
+        time_index_list = df.iloc[:,1].str.strip().tolist()
+        nhd_io.write_single_waterbody_netcdf(
+            wbdyo, 
+            df_empty,
+            df_empty,
+            df_empty,
+            df_empty,
+            df_empty,
+            t0, 
+            dt, 
+            nts,
+            time_index_list
+        )
+        LOG.info("There are no waterbodies in the basin. Single NetCDF Output with all zero values written to folder: "+str(Path(wbdyo).resolve()))
+        #LOG.warning("Requested LAKEOUT files not written. waterbodies_df is empty. Verify gage basin has a waterbody.")
     
     if rsrto:
 

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -383,8 +383,9 @@ def nwm_output_generator(
             nts,
             time_index_list
         )
-        LOG.info("There are no waterbodies in the basin. Single NetCDF Output with all zero values written to folder: "+str(Path(wbdyo).resolve()))
-        #LOG.warning("Requested LAKEOUT files not written. waterbodies_df is empty. Verify gage basin has a waterbody.")
+        LOG.warning("lakeout_output specified with no waterbodies in the basin.")
+        LOG.info("Waterbody output (troute_lakeout.nc) written to folder: "+str(Path(wbdyo).resolve()))
+        
     
     if rsrto:
 

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -314,73 +314,75 @@ def nwm_output_generator(
     if test:
         flowveldepth.to_pickle(Path(test))
     
-    start = time.time()
-    LOG.info("Waterbody output to be written to folder: "+str(Path(wbdyo).resolve()))   
-    num_timesteps = 0
-    if wbdyo and not waterbodies_df.empty:
-        time_index, tmp_variable = map(list,zip(*i_df.columns.tolist()))
-        if not duplicate_ids_df.empty:
-            output_waterbodies_df = waterbodies_df.rename(index=dict(duplicate_ids_df[['synthetic_ids','lake_id']].values))
-            output_waterbody_types_df = waterbody_types_df.rename(index=dict(duplicate_ids_df[['synthetic_ids','lake_id']].values))
-        else:
-            output_waterbodies_df = waterbodies_df
-            output_waterbody_types_df = waterbody_types_df
-        num_timesteps = i_df.shape[1]
-        
-        #Suppress the following function call if you don't need individual timestep netcdfs.
-        #This function can potentially be useful for debugging. So left it here and in nhd_io.py
-        # for i in range(i_df.shape[1]):              
-        #     nhd_io.write_waterbody_netcdf(
-        #         wbdyo, 
-        #         i_df.iloc[:,[i]],
-        #         q_df.iloc[:,[i]],
-        #         d_df.iloc[:,[i]],
-        #         output_waterbodies_df,
-        #         output_waterbody_types_df,
-        #         t0, 
-        #         dt, 
-        #         nts,
-        #         time_index[i]
-        #     )
  
-        nhd_io.write_single_waterbody_netcdf(
-            wbdyo, 
-            i_df,
-            q_df,
-            d_df,
-            output_waterbodies_df,
-            output_waterbody_types_df,
-            t0, 
-            dt, 
-            nts,
-            time_index
-        )
-    elif wbdyo and waterbodies_df.empty:
-        #this portion of the code is used to create lakeout nc files with zero values.
-        df_empty = pd.DataFrame() #empty dataframes for all inputs
+    if wbdyo: #if lakeout_output is present in the YAML file
+        start_time = time.time()
+        num_timesteps = 0
+        if not waterbodies_df.empty: #there are waterbodies in the basin.
+            time_index, tmp_variable = map(list,zip(*i_df.columns.tolist()))
+            if not duplicate_ids_df.empty:
+                output_waterbodies_df = waterbodies_df.rename(index=dict(duplicate_ids_df[['synthetic_ids','lake_id']].values))
+                output_waterbody_types_df = waterbody_types_df.rename(index=dict(duplicate_ids_df[['synthetic_ids','lake_id']].values))
+            else:
+                output_waterbodies_df = waterbodies_df
+                output_waterbody_types_df = waterbody_types_df
+            num_timesteps = i_df.shape[1]
+            
+            #Suppress the following function call if you don't need individual timestep netcdfs.
+            #This function can potentially be useful for debugging. So left it here and in nhd_io.py
+            # for i in range(i_df.shape[1]):              
+            #     nhd_io.write_waterbody_netcdf(
+            #         wbdyo, 
+            #         i_df.iloc[:,[i]],
+            #         q_df.iloc[:,[i]],
+            #         d_df.iloc[:,[i]],
+            #         output_waterbodies_df,
+            #         output_waterbody_types_df,
+            #         t0, 
+            #         dt, 
+            #         nts,
+            #         time_index[i]
+            #     )
+    
+            nhd_io.write_single_waterbody_netcdf(
+                wbdyo, 
+                i_df,
+                q_df,
+                d_df,
+                output_waterbodies_df,
+                output_waterbody_types_df,
+                t0, 
+                dt, 
+                nts,
+                time_index
+            )
+        elif waterbodies_df.empty: #there are no waterbodies in the basin.
+            #this portion of the code is used to create lakeout nc files with zero values.
+            df_empty = pd.DataFrame() #empty dataframes for all inputs
 
-        #use one of the nexus output files to read the timestep datetimes
-        pattern = "nex-*.csv"
-        first_nex_file = next(Path(wbdyo).glob(pattern))
-        df = pd.read_csv(first_nex_file)
-        time_index_list = df.iloc[:,1].str.strip().tolist()
-        num_timesteps = len(time_index_list)
-        nhd_io.write_single_waterbody_netcdf(
-            wbdyo, 
-            df_empty,
-            df_empty,
-            df_empty,
-            df_empty,
-            df_empty,
-            t0, 
-            dt, 
-            nts,
-            time_index_list
-        )
-        LOG.warning("lakeout_output specified with no waterbodies in the basin.")
-    LOG.info("Wrote "+str(num_timesteps)+" timesteps to waterbody netcdf output.") 
-    LOG.info("Waterbody output written to folder: "+str(Path(wbdyo).resolve()))
-    LOG.debug("Writing LAKEOUT netcdf file took a total time of %s seconds." % (time.time() - start))    
+            #use one of the nexus output files to read the timestep datetimes
+            pattern = "nex-*.csv"
+            first_nex_file = next(Path(wbdyo).glob(pattern))
+            df = pd.read_csv(first_nex_file)
+            time_index_list = df.iloc[:,1].str.strip().tolist()
+            num_timesteps = len(time_index_list)
+            nhd_io.write_single_waterbody_netcdf(
+                wbdyo, 
+                df_empty,
+                df_empty,
+                df_empty,
+                df_empty,
+                df_empty,
+                t0, 
+                dt, 
+                nts,
+                time_index_list
+            )
+            LOG.warning("lakeout_output specified with no waterbodies in the basin.")
+        end_time = time.time()
+        LOG.info("Wrote "+str(num_timesteps)+" timesteps to waterbody netcdf output.") 
+        LOG.info("Waterbody output written to folder: "+str(Path(wbdyo).resolve()))
+        LOG.info("Writing LAKEOUT netcdf file took a total time of %s seconds." % (end_time - start_time))    
     
     if rsrto:
 

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -314,7 +314,6 @@ def nwm_output_generator(
     if test:
         flowveldepth.to_pickle(Path(test))
     
- 
     if wbdyo: #if lakeout_output is present in the YAML file
         start_time = time.time()
         num_timesteps = 0
@@ -383,7 +382,9 @@ def nwm_output_generator(
         LOG.info("Wrote "+str(num_timesteps)+" timesteps to waterbody netcdf output.") 
         LOG.info("Waterbody output written to folder: "+str(Path(wbdyo).resolve()))
         LOG.info("Writing LAKEOUT netcdf file took a total time of %s seconds." % (end_time - start_time))    
-    
+    elif not waterbodies_df.empty:
+        LOG.warning("At least 1 waterbody present in basin but lakeout_output not specified in t-route config YAML file. Waterbody data not saved.")
+
     if rsrto:
 
         LOG.info("- writing restart files")

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -314,24 +314,19 @@ def nwm_output_generator(
     if test:
         flowveldepth.to_pickle(Path(test))
     
-    #dropping all data from waterbodies_df for testing. The line below should be deleted before merging.
-    #waterbodies_df = pd.DataFrame(columns=waterbodies_df.columns)
-
+    start = time.time()
+    LOG.info("Waterbody output to be written to folder: "+str(Path(wbdyo).resolve()))   
+    num_timesteps = 0
     if wbdyo and not waterbodies_df.empty:
-        LOG.debug("Writing waterbody output.")
-        
         time_index, tmp_variable = map(list,zip(*i_df.columns.tolist()))
-        LOG.info(i_df.head(5))
         if not duplicate_ids_df.empty:
             output_waterbodies_df = waterbodies_df.rename(index=dict(duplicate_ids_df[['synthetic_ids','lake_id']].values))
             output_waterbody_types_df = waterbody_types_df.rename(index=dict(duplicate_ids_df[['synthetic_ids','lake_id']].values))
         else:
             output_waterbodies_df = waterbodies_df
             output_waterbody_types_df = waterbody_types_df
-        num_files = i_df.shape[1]
-        LOG.info("Single NetCDF Output of "+str(num_files)+" timesteps to be written to folder: "+str(Path(wbdyo).resolve()))     
-        start = time.time()
-
+        num_timesteps = i_df.shape[1]
+        
         #Suppress the following function call if you don't need individual timestep netcdfs.
         #This function can potentially be useful for debugging. So left it here and in nhd_io.py
         # for i in range(i_df.shape[1]):              
@@ -360,8 +355,6 @@ def nwm_output_generator(
             nts,
             time_index
         )
-        LOG.info("Single NetCDF Output of "+str(num_files)+" timesteps written to folder: "+str(Path(wbdyo).resolve()))     
-        LOG.debug("writing LAKEOUT files took a total time of %s seconds." % (time.time() - start))
     elif wbdyo and waterbodies_df.empty:
         #this portion of the code is used to create lakeout nc files with zero values.
         df_empty = pd.DataFrame() #empty dataframes for all inputs
@@ -371,6 +364,7 @@ def nwm_output_generator(
         first_nex_file = next(Path(wbdyo).glob(pattern))
         df = pd.read_csv(first_nex_file)
         time_index_list = df.iloc[:,1].str.strip().tolist()
+        num_timesteps = len(time_index_list)
         nhd_io.write_single_waterbody_netcdf(
             wbdyo, 
             df_empty,
@@ -384,8 +378,9 @@ def nwm_output_generator(
             time_index_list
         )
         LOG.warning("lakeout_output specified with no waterbodies in the basin.")
-        LOG.info("Waterbody output (troute_lakeout.nc) written to folder: "+str(Path(wbdyo).resolve()))
-        
+    LOG.info("Wrote "+str(num_timesteps)+" timesteps to waterbody netcdf output.") 
+    LOG.info("Waterbody output written to folder: "+str(Path(wbdyo).resolve()))
+    LOG.debug("Writing LAKEOUT netcdf file took a total time of %s seconds." % (time.time() - start))    
     
     if rsrto:
 


### PR DESCRIPTION
Requirement: The lakeout output file is always generated if the lakeout_output is specified in the t-route config file regardless of whether waterbodies are present or not.

## Additions

- Added a logical block in src/troute-nwm/src/nwm-routing/output.py in the nwm_output_generator function to capture the situation when the waterbodies data is empty. The timeseries data is read from a nexus output file produced from the model run and empty dataframes produced.
- Added logic in src/troute-network/troute/nhd_io.py to create the netcdf with zero values for inflow, outflow, depth, and waterbody type.
- Added a `basin-characteristics` entry in the metadata of the netCDF file when a waterbody is not present in the basin.

## Changes

- Changed the output name for the lakeout file to "troute_lakeout.nc". It was previously named as "<feature_id>.LAKEOUT.nc

## Testing

1. Tested with a basin that did not contain a waterbody, gauge 12114500, and one that does contain a waterbody, gauge CNF.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

