### PR TITLE
Fix pandas dataframe slice warning when setting the hl_link item value

### DIFF
--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -124,7 +124,8 @@ def read_geopkg(file_path, compute_parameters, waterbody_parameters, cpu_pool):
         hydro = table_dict["hydrolocations"]
 
         # Filter out non-integer hl_link values and convert to integer (assuming valid lake_id values are integers)
-        hydro = hydro[hydro["hl_link"].apply(lambda x: str(x).replace(".", "", 1).isdigit())]
+        mask = hydro["hl_link"].apply(lambda x: str(x).replace(".", "", 1).isdigit())
+        hydro = hydro.loc[mask].copy()
         hydro["hl_link"] = hydro["hl_link"].astype(int)
 
         if not lakes.empty: 


### PR DESCRIPTION
When running t-route with a waterbody in the gage basin, the following pandas warning was issued:

```
.../ngen/extern/t-route/src/troute-network/troute/HYFeaturesNetwork.py:128: SettingWithCopyWarning: 
A value is trying to be set on a copy of a slice from a DataFrame.
Try using .loc[row_indexer,col_indexer] = value instead

See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
  hydro["hl_link"] = hydro["hl_link"].astype(int)
```

Pandas issues this because it’s not sure if the assignment will safely modify the data in place or affect the parent table_dict["hydrolocations"]. 

This PR contains the recommendation to use `.loc` and `copy` before assigning the value.

## Changes

- Updated the original assignment of `hydro` to use the `mask` variable instead, then using `mask` with `.loc` and `.copy`, created a copy of the data frame slice in `hydro`. 

## Testing

1. Successfully ran t-route on a gage with a waterbody and the warning was not issued.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
