### PR TITLE
Remove nexus file read in BMI implementation (NGWPC-8769)

### DIFF
--- a/src/troute-bmi/src/troute_nwm_bmi/troute_bmi.py
+++ b/src/troute-bmi/src/troute_nwm_bmi/troute_bmi.py
@@ -28,7 +28,9 @@ class BmiTroute(Bmi):
         super().__init__()
         self._values = {
             "land_surface_water_source__id": np.zeros(0, dtype=np.intc),
+            "land_surface_water_source__id" + _COUNT_SUFFIX: np.zeros(1, dtype=np.int64),
             "land_surface_water_source__volume_flow_rate": np.zeros(0, dtype=float),
+            "land_surface_water_source__volume_flow_rate" + _COUNT_SUFFIX: np.zeros(1, dtype=np.int64),
             "upstream_id": np.zeros(0, dtype=int),
         }
         self._var_loc = "node"
@@ -63,8 +65,7 @@ class BmiTroute(Bmi):
             source_var_name = var_name[:-len(_COUNT_SUFFIX)]
             source = self._values.get(source_var_name)
             self._values[source_var_name] = np.resize(source, int(src[0]))
-        else:
-            self._values[var_name] = src
+        self._values[var_name][:] = src
 
     def get_value(self, var_name: str):
         """Copy of values.
@@ -77,12 +78,7 @@ class BmiTroute(Bmi):
         output_df : pd.DataFrame
             Copy of values.
         """
-        if var_name.endswith(_COUNT_SUFFIX):
-            source_var_name = var_name[:-len(_COUNT_SUFFIX)]
-            source = self._values[source_var_name]
-            return np.array([len(source)], dtype=np.int64)
-        else:
-            return np.copy(self._values[var_name])
+        return np.copy(self._values[var_name])
 
     def get_value_ptr(self, var_name: str):
         """Reference to values.

--- a/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
+++ b/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
@@ -69,7 +69,7 @@ class Model:
         network_creation_time = time.time() - network_start_time
 
         # Data data assimilation
-        LOG.info("Creating DataAssimilation object")
+        LOG.debug("Creating DataAssimilation object")
         forcing_start_time = time.time()
         da_run = {}
         if self.data_assimilation_parameters:
@@ -119,7 +119,7 @@ class Model:
         nts = self.nts
         qts_subdivisions = self.forcing_parameters.get('qts_subdivisions', 12)
 
-        LOG.info("Assembling forcing dataframe")
+        LOG.debug("Assembling forcing dataframe")
         forcing_start_time = time.time()
         ## setup the qlats dataframe from the update() data
         qlats = pd.DataFrame(data=self._df_data, index=bmi_values["land_surface_water_source__id"])
@@ -136,7 +136,7 @@ class Model:
         else:
             flowveldepth_interorder = {}
 
-        LOG.info("Starting routing function")
+        LOG.debug("Starting routing function")
         route_start_time = time.time()
         run_results, self._subnetwork = nwm_routing.nwm_route(
             downstream_connections=self._network.connections,
@@ -192,7 +192,7 @@ class Model:
         # update reservoir parameters and lastobs_df
         self._data_assimilation.update_after_compute(run_results, self.dt * nts)
 
-        LOG.info("Generating output")
+        LOG.debug("Generating output")
         output_start_time = time.time()
         run_params = {
             "t0": self.t0,

--- a/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
+++ b/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
@@ -35,6 +35,7 @@ class Model:
 
         self.dt = int(self.forcing_parameters["dt"])
 
+        LOG.info("Creating network of type " + self.supernetwork_parameters.get("network_type"))
         network_start_time = time.time()
         if self.supernetwork_parameters["network_type"] == "HYFeaturesNetwork":
             self._network = HYFeaturesNetwork(
@@ -68,6 +69,7 @@ class Model:
         network_creation_time = time.time() - network_start_time
 
         # Data data assimilation
+        LOG.info("Creating DataAssimilation object")
         forcing_start_time = time.time()
         da_run = {}
         if self.data_assimilation_parameters:
@@ -76,7 +78,8 @@ class Model:
                 "final_timestamp": self.t0 + timedelta(seconds=self.nts * self.dt)
             }
             da_sets = hnu.build_da_sets(self.data_assimilation_parameters, [run_set], self._network.t0)
-            da_run = da_sets[0]
+            if da_sets:
+                da_run = da_sets[0]
         self._data_assimilation = DataAssimilation(
             network=self._network,
             data_assimilation_parameters=self.data_assimilation_parameters,
@@ -103,17 +106,21 @@ class Model:
 
 
     def update(self, bmi_values: dict):
+        start = time.time()
         qlat_values = bmi_values["land_surface_water_source__volume_flow_rate"]
-        time = self._network.t0 + timedelta(seconds=self.time)
-        timestamp = time.strftime("%Y%m%d%H%M")
+        step_time = self._network.t0 + timedelta(seconds=self.time)
+        timestamp = step_time.strftime("%Y%m%d%H%M")
         self._df_data[timestamp] = np.array(qlat_values)
         self._time += self.dt
+        self._timings["forcing_time"] += time.time() - start
 
 
     def run(self, bmi_values: dict):
         nts = self.nts
         qts_subdivisions = self.forcing_parameters.get('qts_subdivisions', 12)
 
+        LOG.info("Assembling forcing dataframe")
+        forcing_start_time = time.time()
         ## setup the qlats dataframe from the update() data
         qlats = pd.DataFrame(data=self._df_data, index=bmi_values["land_surface_water_source__id"])
         # Take flowpath ids entering NEXUS and replace NEXUS ids by the upstream flowpath ids
@@ -122,12 +129,14 @@ class Model:
         missing = self._network.segment_index[~self._network.segment_index.isin(qlats.index)]
         zeros = pd.DataFrame(data=0.0, index=missing, columns=qlats.columns)
         qlats = pd.concat([qlats, zeros]).sort_index()
+        self._timings["forcing_time"] += time.time() - forcing_start_time
 
         if len(bmi_values["upstream_id"]) > 0:
             flowveldepth_interorder = {bmi_values['upstream_id'][0]: {"results": bmi_values['upstream_fvd']}}
         else:
             flowveldepth_interorder = {}
 
+        LOG.info("Starting routing function")
         route_start_time = time.time()
         run_results, self._subnetwork = nwm_routing.nwm_route(
             downstream_connections=self._network.connections,
@@ -183,6 +192,7 @@ class Model:
         # update reservoir parameters and lastobs_df
         self._data_assimilation.update_after_compute(run_results, self.dt * nts)
 
+        LOG.info("Generating output")
         output_start_time = time.time()
         run_params = {
             "t0": self.t0,

--- a/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
+++ b/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
@@ -67,14 +67,16 @@ class Model:
             raise Exception("Supernetwork network type must be HYFeaturesNetwork or NHDNetwork")
         network_creation_time = time.time() - network_start_time
 
-        self._run_sets = self._network.build_forcing_sets()
-
         # Data data assimilation
         forcing_start_time = time.time()
+        da_run = {}
         if self.data_assimilation_parameters:
-            self._da_sets = hnu.build_da_sets(self.data_assimilation_parameters, self._run_sets, self._network.t0)
-        else:
-            self._da_sets = []
+            run_set = {
+                "nts": self.nts,
+                "final_timestamp": self.t0 + timedelta(seconds=self.nts * self.dt)
+            }
+            da_sets = hnu.build_da_sets(self.data_assimilation_parameters, [run_set], self._network.t0)
+            da_run = da_sets[0]
         self._data_assimilation = DataAssimilation(
             network=self._network,
             data_assimilation_parameters=self.data_assimilation_parameters,
@@ -82,7 +84,7 @@ class Model:
             waterbody_parameters=self.waterbody_parameters,
             from_files=True,
             value_dict=None,
-            da_run=self._da_sets[0] if len(self._da_sets) else {},
+            da_run=da_run,
         )
         forcing_time = time.time() - forcing_start_time
 


### PR DESCRIPTION
The BMI implementation still read the nexus files once when the network would build data used by the DataAssimilation object. Having the model create the data removes this IO data read.

Efforts made to remove the possibility of dangling pointers when communicating with ngen's C++ adapter. The `__count` variants of variables are stored in the `_values` dict so `get_value_ptr` can return a permanent object. When calling `set_value`, the source array is copied into the existing backing numpy array.

This is also part of addressing NGWPC-8862 and NGWPC-8882, along with NGWPC/ngen#70

## Additions

- More logs for getting information on where errors might occur in the BMI implementation.
- Timing instrumentation for forcing inputs

## Removals

- Call to AbstractNetwork.build_forcing_sets()

## Changes

- Run set used in DataAssimilation instantiation generated by the model instead of AbstractNetwork.
- `set_value` will copy values into the existing array instead of replacing the value.

## Testing

1.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
