### PR TITLE
EWTS Logging Does Not Use Global Default

### DIFF
--- a/src/model_DAforcing.py
+++ b/src/model_DAforcing.py
@@ -17,9 +17,8 @@ import bmi_df2array as df2a
 
 from troute.routing.fast_reach.reservoir_RFC_da import _validate_RFC_data
 import netCDF4
-from nwm_routing.log_level_set import log_level_set
+from nwm_routing.log_level_set import log_level_set, MODULE_NAME
 from troute.config import Config
-from nwm_routing.log_level_set import MODULE_NAME
 
 LOG = logging.getLogger(MODULE_NAME)
 

--- a/src/model_DAforcing.py
+++ b/src/model_DAforcing.py
@@ -19,7 +19,9 @@ from troute.routing.fast_reach.reservoir_RFC_da import _validate_RFC_data
 import netCDF4
 from nwm_routing.log_level_set import log_level_set
 from troute.config import Config
-LOG = logging.getLogger('')
+from nwm_routing.log_level_set import MODULE_NAME
+
+LOG = logging.getLogger(MODULE_NAME)
 
 class DAforcing_model():
 

--- a/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
+++ b/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
@@ -15,9 +15,9 @@ import troute.hyfeature_network_utilities as hnu
 
 import nwm_routing.__main__ as nwm_routing
 from nwm_routing.output import nwm_output_generator
-from nwm_routing.log_level_set import log_level_set
+from nwm_routing.log_level_set import log_level_set, MODULE_NAME
 
-LOG = logging.getLogger("")
+LOG = logging.getLogger(MODULE_NAME)
 
 
 class Model:

--- a/src/troute-network/troute/AbstractNetwork.py
+++ b/src/troute-network/troute/AbstractNetwork.py
@@ -18,7 +18,9 @@ from troute.nhd_network_utilities_v02 import organize_independent_networks
 import troute.nhd_io as nhd_io 
 from .AbstractRouting import MCOnly, MCwithDiffusive, MCwithDiffusiveNatlXSectionNonRefactored, MCwithDiffusiveNatlXSectionRefactored
 
-LOG = logging.getLogger('')
+from nwm_routing.log_level_set import MODULE_NAME
+
+LOG = logging.getLogger(MODULE_NAME)
 
 class AbstractNetwork(ABC):
     """

--- a/src/troute-network/troute/AbstractRouting.py
+++ b/src/troute-network/troute/AbstractRouting.py
@@ -9,7 +9,9 @@ from itertools import chain
 from troute.nhd_network import reverse_network, reachable
 from troute.nhd_network_utilities_v02 import organize_independent_networks, build_refac_connections
 
-LOG = logging.getLogger('')
+from nwm_routing.log_level_set import MODULE_NAME
+
+LOG = logging.getLogger(MODULE_NAME)
 
 def read_diffusive_domain(domain_file):
     '''

--- a/src/troute-network/troute/DataAssimilation.py
+++ b/src/troute-network/troute/DataAssimilation.py
@@ -11,10 +11,13 @@ import re
 import time
 import logging
 
-LOG = logging.getLogger('')
 from troute.routing.fast_reach.reservoir_RFC_da import _validate_RFC_data
 
 from troute.network import bmi_array2df as a2df
+
+from nwm_routing.log_level_set import MODULE_NAME
+
+LOG = logging.getLogger(MODULE_NAME)
 
 # set legacy run flag: option to pass data frames through BMI formalism 
 # not to be used in regular BMI runs any longer, only for debugging

--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -36,6 +36,7 @@ def find_layer_name(layers, pattern):
 
 
 def read_geopkg(file_path, compute_parameters, waterbody_parameters, cpu_pool):
+    print("reading geopkg")
     # Retrieve available layers from the GeoPackage
     available_layers = fiona.listlayers(file_path)
 
@@ -50,6 +51,7 @@ def read_geopkg(file_path, compute_parameters, waterbody_parameters, cpu_pool):
     }
 
     # Match available layers to the patterns
+    print("finding layers")
     matched_layers = {key: find_layer_name(available_layers, pattern) for key, pattern in layer_patterns.items()}
 
     layers_to_read = ["flowpaths", "flowpath_attributes", "hydrolocations"]
@@ -85,12 +87,17 @@ def read_geopkg(file_path, compute_parameters, waterbody_parameters, cpu_pool):
         return pd.DataFrame()
 
     # Retrieve geopackage information using matched layer names
+    print("about to read")
     if cpu_pool > 1:
+        print("with parallel")
+        import sys
+        print(sys.executable)
         with Parallel(n_jobs=min(cpu_pool, len(layers_to_read))) as parallel:
             gpkg_list = parallel(delayed(read_layer)(matched_layers[layer]) for layer in layers_to_read)
 
         table_dict = {layers_to_read[i]: gpkg_list[i] for i in range(len(layers_to_read))}
     else:
+        print("without parallel")
         table_dict = {layer: read_layer(matched_layers[layer]) for layer in layers_to_read}
 
     # Handle different key column names between flowpaths and flowpath_attributes
@@ -350,14 +357,18 @@ class HYFeaturesNetwork(AbstractNetwork):
                 from_files = False
 
             # Preprocess network objects
+            print("preprocess_network")
             self.preprocess_network(flowpaths, nexus)
 
+            print("crosswalk_nex_flowpath_poi")
             self.crosswalk_nex_flowpath_poi(flowpaths, nexus)
 
             # Preprocess waterbody objects
+            print("preprocess_waterbodies")
             self.preprocess_waterbodies(lakes, nexus)
 
             # Preprocess data assimilation objects #TODO: Move to DataAssimilation.py?
+            print("preprocess_data_assimilation")
             self.preprocess_data_assimilation(network)
 
             if self.preprocessing_parameters.get("preprocess_output_folder", None):

--- a/src/troute-network/troute/NHDNetwork.py
+++ b/src/troute-network/troute/NHDNetwork.py
@@ -12,7 +12,9 @@ import pyarrow.parquet as pq
 from troute.nhd_network import reverse_dict, extract_waterbody_connections, gage_mapping, extract_connections, replace_waterbodies_connections
 
 import logging
-LOG = logging.getLogger('')
+from nwm_routing.log_level_set import MODULE_NAME
+
+LOG = logging.getLogger(MODULE_NAME)
 
 __showtiming__ = True #FIXME pass flag
 __verbose__ = True #FIXME pass verbosity

--- a/src/troute-network/troute/hyfeature_network_utilities.py
+++ b/src/troute-network/troute/hyfeature_network_utilities.py
@@ -14,8 +14,9 @@ import pyarrow.parquet as pq
 
 import troute.nhd_io as nhd_io
 
+from nwm_routing.log_level_set import MODULE_NAME
 
-LOG = logging.getLogger('')
+LOG = logging.getLogger(MODULE_NAME)
 
 
 def build_da_sets(da_params, run_sets, t0):

--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -20,7 +20,9 @@ from datetime import datetime, timedelta
 
 from troute.nhd_network import reverse_dict
 
-LOG = logging.getLogger('')
+from nwm_routing.log_level_set import MODULE_NAME
+
+LOG = logging.getLogger(MODULE_NAME)
 
 def read_netcdf(geo_file_path):
     '''

--- a/src/troute-network/troute/nhd_network_utilities_v02.py
+++ b/src/troute-network/troute/nhd_network_utilities_v02.py
@@ -12,7 +12,9 @@ from joblib import delayed, Parallel
 import troute.nhd_io as nhd_io
 import troute.nhd_network as nhd_network
 
-LOG = logging.getLogger('')
+from nwm_routing.log_level_set import MODULE_NAME
+
+LOG = logging.getLogger(MODULE_NAME)
 
 def build_connections(supernetwork_parameters):
     '''

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -30,8 +30,9 @@ import troute.nhd_network_utilities_v02 as nnu
 import troute.hyfeature_network_utilities as hnu
 import sys
 
+from nwm_routing.log_level_set import MODULE_NAME
 
-LOG = logging.getLogger('')
+LOG = logging.getLogger(MODULE_NAME)
 
 '''
 High level orchestration of ngen t-route simulations for NWM application

--- a/src/troute-nwm/src/nwm_routing/input.py
+++ b/src/troute-nwm/src/nwm_routing/input.py
@@ -6,10 +6,8 @@ import yaml
 
 import troute.nhd_io as nhd_io
 import troute.nhd_network_utilities_v02 as nnu
-from .log_level_set import log_level_set
+from .log_level_set import log_level_set, MODULE_NAME
 from troute.config import Config
-
-from nwm_routing.log_level_set import MODULE_NAME
 
 LOG = logging.getLogger(MODULE_NAME)
 

--- a/src/troute-nwm/src/nwm_routing/input.py
+++ b/src/troute-nwm/src/nwm_routing/input.py
@@ -9,7 +9,9 @@ import troute.nhd_network_utilities_v02 as nnu
 from .log_level_set import log_level_set
 from troute.config import Config
 
-LOG = logging.getLogger('')
+from nwm_routing.log_level_set import MODULE_NAME
+
+LOG = logging.getLogger(MODULE_NAME)
 
 def _input_handler_v04(args):
     '''
@@ -120,7 +122,7 @@ def _input_handler_v03(args):
 
     # configure python logger
     log_level_set(log_parameters)
-    LOG = logging.getLogger('')
+    LOG = logging.getLogger(MODULE_NAME)
 
     # if log level is at or below DEBUG, then check user inputs
     if LOG.isEnabledFor(logging.DEBUG):

--- a/src/troute-nwm/src/nwm_routing/log_level_set.py
+++ b/src/troute-nwm/src/nwm_routing/log_level_set.py
@@ -178,24 +178,25 @@ def log_level_set(input_parameters):
         handler.setFormatter(formatter)
 
         # Setup root logger
-        logging.getLogger().handlers.clear()  # Clear any default handlers
-        logging.getLogger().setLevel(translate_ngwpc_log_level(log_level))
-        logging.getLogger().addHandler(handler)
+        logger = logging.getLogger(MODULE_NAME)
+        logger.handlers.clear()  # Clear any default handlers
+        logger.setLevel(translate_ngwpc_log_level(log_level))
+        logger.addHandler(handler)
 
         # Ensure UTC timestamps
         logging.Formatter.converter = time.gmtime
 
         # Save the current log level
-        current_level = logging.getLogger().getEffectiveLevel()
+        current_level = logger.getEffectiveLevel()
 
         try:
             # Temporarily set log level to INFO
-            logging.getLogger().setLevel(logging.INFO)
+            logger.setLevel(logging.INFO)
             
             # Log the message at INFO level
             logging.info(f"Log level set to {log_level}")
             print(f"Module {MODULE_NAME} Log Level set to {log_level}")
         finally:
             # Restore the original log level
-            logging.getLogger().setLevel(current_level)
+            logger.setLevel(current_level)
     

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -7,7 +7,9 @@ import troute.nhd_io as nhd_io
 from build_tests import parity_check
 import logging
 
-LOG = logging.getLogger('')
+from nwm_routing.log_level_set import MODULE_NAME
+
+LOG = logging.getLogger(MODULE_NAME)
 
 def _reindex_lake_to_link_id(target_df, crosswalk):
     '''

--- a/src/troute-nwm/src/nwm_routing/preprocess.py
+++ b/src/troute-nwm/src/nwm_routing/preprocess.py
@@ -12,7 +12,9 @@ import troute.nhd_network_utilities_v02 as nnu
 import troute.nhd_network as nhd_network
 import troute.nhd_io as nhd_io
 
-LOG = logging.getLogger('')
+from nwm_routing.log_level_set import MODULE_NAME
+
+LOG = logging.getLogger(MODULE_NAME)
 
 def _reindex_link_to_lake_id(target_df, crosswalk):
     '''

--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -16,7 +16,9 @@ from troute.routing.fast_reach import diffusive
 
 import logging
 
-LOG = logging.getLogger('')
+from nwm_routing.log_level_set import MODULE_NAME
+
+LOG = logging.getLogger(MODULE_NAME)
 
 _compute_func_map = defaultdict(
     compute_network_structured,

--- a/src/troute-routing/troute/routing/fast_reach/reservoir_GL_da.py
+++ b/src/troute-routing/troute/routing/fast_reach/reservoir_GL_da.py
@@ -1,7 +1,9 @@
 import numpy as np
 import logging
 from datetime import datetime, timedelta
-LOG = logging.getLogger('')
+from nwm_routing.log_level_set import MODULE_NAME
+
+LOG = logging.getLogger(MODULE_NAME)
 
 def great_lakes_da(
     gage_obs,

--- a/src/troute-routing/troute/routing/fast_reach/reservoir_hybrid_da.py
+++ b/src/troute-routing/troute/routing/fast_reach/reservoir_hybrid_da.py
@@ -1,6 +1,8 @@
 import numpy as np
 import logging
-LOG = logging.getLogger('')
+from nwm_routing.log_level_set import MODULE_NAME
+
+LOG = logging.getLogger(MODULE_NAME)
 
 def _modify_for_projected_storage(
     inflow, 


### PR DESCRIPTION
Logging was previously done with `logging.getLogger("")` to synchronize between files. This method could cause different ngen modules running on the same python interpreter to overwrite which module is responsible for the message. This update changes the logger to use `"T-route"` as its logger name to prevent this potential conflict.

## Changes

- Use the module's name ("T-route") for all instances of logging.

## Testing

1.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [x] Windows
- [x] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
