### PR TITLE
Unify pydantic minimum version to currently latest patch release of 2.11 (2.11.9)

### DIFF
--- a/src/troute-config/pyproject.toml
+++ b/src/troute-config/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
   "Topic :: Utilities",
 ]
 dependencies = [
-  "pydantic==2.11.4",
+  "pydantic~=2.11.9",
   "typing_extensions",
 ]
 description = "Modules for validating and programatically accessing troute configuration files."

--- a/src/troute-rnr/pyproject.toml
+++ b/src/troute-rnr/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.9"
 name = "troute_rnr"
 authors = [{ name = "Tadd Bindas", email = "Tadd.Bindas@rtx.com" }]
 dependencies = [
-    "pydantic==2.11.4",
+    "pydantic~=2.11.9",
     "pydantic-xml==2.16.0",
     "httpx==0.27.0",
     "geopandas==1.0.1",


### PR DESCRIPTION
This PR includes updates to pyproject.toml to resolve current and potential future dependency conflicts among other NGWPC packages.

## Changes

Allow variability in patch version of Pydantic, set minimum patch version to 2.11.9

## Testing

ngen calibration and forecasting functionality was performed in a Docker image containing package updates of this branch name (`maxkipp-ngwpc-8941-upgrade-shapely-2`) across many repos.

## Checklist

- [x] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [x] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
