### PR TITLE
Add Error Warning and Trapping System (EWTS) for T-Route C modules

### DIFF
--- a/src/troute-network/.gitignore
+++ b/src/troute-network/.gitignore
@@ -8,3 +8,4 @@ libs/*
 !*mc_reach_structs.c
 !*levelpool_structs.c
 !*reach_structs.c
+!*logger.c

--- a/src/troute-network/setup.py
+++ b/src/troute-network/setup.py
@@ -89,6 +89,7 @@ levelpool_reservoirs = Extension(
     "troute.network.reservoirs.levelpool.levelpool",
     sources=[
              "troute/network/reservoirs/levelpool/levelpool.{}".format(ext),
+             "troute/network/logger.c",
              ],
     include_dirs=[np.get_include(),  "troute/network/"],
     extra_objects=["./libs/binding_lp.a"],
@@ -119,7 +120,7 @@ rfc_reservoirs = Extension(
 )
 
 package_data = {"troute": ["__init__.pxd"],
-                "troute.network": ["reach.pxd", "__init__.pxd", "reach_structs.h", "reach_structs.c"],
+                "troute.network": ["reach.pxd", "__init__.pxd", "reach_structs.h", "reach_structs.c", "logger.h"],
                 "troute.network.musking": ["mc_reach.pxd", "__init__.pxd", "mc_reach_structs.h", "mc_reach_structs.c"],
                 "troute.network.reservoirs":["__init__.pxd"],
                 "troute.network.reservoirs.levelpool":["__init__.pxd", "levelpool.pxd", "levelpool_structs.h", "levelpool_structs.c"],

--- a/src/troute-network/setup.py
+++ b/src/troute-network/setup.py
@@ -91,7 +91,7 @@ levelpool_reservoirs = Extension(
              "troute/network/reservoirs/levelpool/levelpool.{}".format(ext),
              "troute/network/logger.c",
              ],
-    include_dirs=[np.get_include(),  "troute/network/"],
+    include_dirs=[np.get_include(), "troute/network/"],
     extra_objects=["./libs/binding_lp.a"],
     libraries=["netcdff", "netcdf"],
     extra_compile_args=["-g"],
@@ -101,8 +101,9 @@ levelpool_reservoirs = Extension(
 #    "troute.network.reservoirs.hybrid.hybrid",
 #    sources=[
 #             "troute/network/reservoirs/hybrid/hybrid.{}".format(ext),
+#             "troute/network/logger.c",
 #             ],
-#    include_dirs=[np.get_include()],
+#    include_dirs=[np.get_include(), "troute/network/"],
 #    extra_objects=["./libs/bind_hybrid.a"],
 #    libraries=["netcdff", "netcdf"],
 #    extra_compile_args=["-g"],
@@ -112,6 +113,7 @@ rfc_reservoirs = Extension(
     "troute.network.reservoirs.rfc.rfc",
     sources=[
              "troute/network/reservoirs/rfc/rfc.{}".format(ext),
+             "troute/network/logger.c",
              ],
     include_dirs=[np.get_include(),  "troute/network/"],
     extra_objects=["./libs/bind_rfc.a"],

--- a/src/troute-network/troute/network/logger.c
+++ b/src/troute-network/troute/network/logger.c
@@ -1,0 +1,373 @@
+#include "logger.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <errno.h>
+#include <time.h>
+#include <unistd.h>
+#include <ctype.h>
+#include <stdbool.h>
+
+// Define Environment Variable Names
+#define MODULE_NAME           "T-Route"
+#define LOG_DIR_NGENCERF      "/ngencerf/data"        // ngenCERF log directory
+#define LOG_DIR_DEFAULT       "run-logs"              // Default subdir if ngen log file env not found
+#define LOG_FILE_EXT          "log"                   // Log file name extension
+#define DS                    "/"                     // Directory separator
+#define LOG_MODULE_NAME_LEN   8                       // Width of module name for log entries
+
+#define EV_EWTS_LOGGING       "NGEN_EWTS_LOGGING"     // Enable/disable of Error Warning and Trapping System  
+#define EV_NGEN_LOGFILEPATH   "NGEN_LOG_FILE_PATH"    // ngen log file 
+#define EV_MODULE_LOGLEVEL    "TROUTE_LOGLEVEL"       // This modules log level
+#define EV_MODULE_LOGFILEPATH "TROUTE_LOGFILEPATH"    // This modules log full log filename
+
+
+bool     loggingEnabled = true;
+bool     openedAppendMode = true;
+bool     loggerInitialized = false;
+FILE*    logFile = NULL;
+char     logFilePath[1024] = "";
+LogLevel logLevel = INFO;
+char     moduleName[LOG_MODULE_NAME_LEN+1] = "";
+
+void TrimString(const char *input, char *output, size_t outputSize) {
+    if (!input || !output || outputSize == 0) {
+        if (output && outputSize > 0) output[0] = '\0';
+        return;
+    }
+
+    // Skip leading whitespace
+    while (isspace((unsigned char)*input)) {
+        input++;
+    }
+
+    size_t len = strlen(input);
+    if (len == 0) {
+        output[0] = '\0';
+        return;
+    }
+
+    // Find the end of the string and move backward past trailing whitespace
+    const char *end = input + len - 1;
+    while (end > input && isspace((unsigned char)*end)) {
+        end--;
+    }
+
+    size_t trimmedLen = end - input + 1;
+    if (trimmedLen >= outputSize) {
+        trimmedLen = outputSize - 1;
+    }
+
+    strncpy(output, input, trimmedLen);
+    output[trimmedLen] = '\0';
+}
+
+void SetLogModuleName(void) {
+
+    // Copy MODULE_NAME to a string variable 
+    char src[20];
+    strncpy(src, MODULE_NAME, sizeof(src));
+    src[sizeof(src) - 1] = '\0'; // ensure null termination
+
+    // Convert to uppercase and copy, up to width or null terminator
+    size_t i = 0;
+    for (; i < LOG_MODULE_NAME_LEN && src[i] != '\0'; i++) {
+        moduleName[i] = toupper((unsigned char)src[i]);
+    }
+
+    // Pad with spaces if needed
+    for (; i < LOG_MODULE_NAME_LEN; i++) {
+        moduleName[i] = ' ';
+    }
+    moduleName[LOG_MODULE_NAME_LEN] = '\0'; // null-terminate
+}
+
+void CreateTimestamp(char *buffer, size_t size, bool appendMS, bool iso) {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+
+    struct tm utc_tm;
+    gmtime_r(&tv.tv_sec, &utc_tm);
+
+    char base[32];
+    if (iso) {
+        strftime(base, sizeof(base), "%Y-%m-%dT%H:%M:%S", &utc_tm);
+    } else {
+        strftime(base, sizeof(base), "%Y%m%dT%H%M%S", &utc_tm);
+    }
+
+    if (appendMS) {
+        snprintf(buffer, size, "%s.%03ld", base, tv.tv_usec / 1000);
+    } else {
+        snprintf(buffer, size, "%s", base);
+    }
+}
+
+bool DirectoryExists(const char *path) {
+    struct stat info;
+    return (stat(path, &info) == 0 && (info.st_mode & S_IFDIR));
+}
+
+bool CreateDirectory(const char *path) {
+    if (!DirectoryExists(path)) {
+        char cmd[512];
+        snprintf(cmd, sizeof(cmd), "mkdir -p \"%s\"", path);
+        int status = system(cmd);
+        if (status == -1 || (WIFEXITED(status) && WEXITSTATUS(status) != 0)) {
+            fprintf(stderr, "Failed to create directory: %s\n", path);
+            return false;
+        }
+    }
+    return true;
+}
+
+bool LogFileReady(bool appendMode) {
+    if (logFile && !ferror(logFile)) {
+        fseek(logFile, 0, SEEK_END);
+        return true;
+    } else if (strlen(logFilePath) > 0) {
+        logFile = fopen(logFilePath, appendMode ? "a" : "w");
+        if (logFile != NULL) {
+            openedAppendMode = appendMode;
+            return true;
+        }
+        return false;
+    }
+    return false;
+}
+
+/**
+ * Set the log file path name using the following pattern
+ *  - Use the module log file if available (unset when first run by ngen), otherwise 
+ *  - Use ngen log file if available, otherwise
+ *  - Use /ngencerf/data/run-logs/<username>/<module>_<YYMMDDTHHMMSS> if available, othrewise
+ *  - Use ~/run-logs/<YYYYMMDD>/<module>_<YYMMDDTHHMMSS>
+ *  - Onced opened, save the full log path to the modules log environment variable so
+ *    it is only opened once for each ngen run (vs for each catchment)
+ */
+void SetupLogFile(void) {
+    logFilePath[0] = '\0';
+    bool appendEntries = true;
+    bool moduleLogEnvExists = false;
+
+    const char *envVar = getenv(EV_MODULE_LOGFILEPATH);
+    if (envVar && envVar[0] != '\0') {
+        strncpy(logFilePath, envVar, sizeof(logFilePath) - 1);
+        moduleLogEnvExists = true;
+    } else {
+        envVar = getenv(EV_NGEN_LOGFILEPATH);
+        if (envVar && envVar[0] != '\0') {
+            strncpy(logFilePath, envVar, sizeof(logFilePath) - 1);
+        } else {
+            appendEntries = false;
+            char logFileDir[512];
+
+            if (DirectoryExists(LOG_DIR_NGENCERF)) {
+                snprintf(logFileDir, sizeof(logFileDir), "%s%s%s", LOG_DIR_NGENCERF, DS, LOG_DIR_DEFAULT);
+            } else {
+                const char *home = getenv("HOME"); // Get users home directly pathname
+                if (home) {
+                    snprintf(logFileDir, sizeof(logFileDir), "%s%s%s", home, DS, LOG_DIR_DEFAULT);
+                }
+                else {
+                    snprintf(logFileDir, sizeof(logFileDir), "~%s%s", DS, LOG_DIR_DEFAULT);
+                }
+            }
+
+            if (CreateDirectory(logFileDir)) {
+                const char *envUsername = getenv("USER");
+                if (envUsername) {
+                    strncat(logFileDir, DS, sizeof(logFileDir) - strlen(logFileDir) - 1);
+                    strncat(logFileDir, envUsername, sizeof(logFileDir) - strlen(logFileDir) - 1);
+                } else {
+                    char dateStr[32];
+                    CreateTimestamp(dateStr, sizeof(dateStr), 0, 0);
+                    strncat(logFileDir, DS, sizeof(logFileDir) - strlen(logFileDir) - 1);
+                    strncat(logFileDir, dateStr, sizeof(logFileDir) - strlen(logFileDir) - 1);
+                }
+
+                if (CreateDirectory(logFileDir)) {
+                    char timestamp[32];
+                    CreateTimestamp(timestamp, sizeof(timestamp), 0, 0);
+                    snprintf(logFilePath, sizeof(logFilePath), "%s%s%s_%s.%s",
+                             logFileDir, DS, MODULE_NAME, timestamp, LOG_FILE_EXT);
+                }
+            }
+        }
+    }
+
+    if (LogFileReady(appendEntries)) {
+        if (!moduleLogEnvExists) setenv(EV_MODULE_LOGFILEPATH, logFilePath, 1);
+        else {
+            printf("%s C Logger: T-Route Python logger already set env var %s=%s\n", MODULE_NAME, EV_MODULE_LOGFILEPATH, logFilePath);
+            fflush(stdout); // Force flushing of stdout
+        }
+        printf("%s C Logger: Opened log file %s in %s mode\n", MODULE_NAME, logFilePath, (openedAppendMode ? "Append" : "Truncate"));
+        fflush(stdout); // Force flushing of stdout
+    } else {
+        printf("[ERROR] %s C Logger: Unable to open log file ", MODULE_NAME);
+        if (strlen(logFilePath) > 0) {
+            printf("[%s (Perhaps check permissions)\n", logFilePath);
+        }
+        else printf("\n");
+        printf("[WARNING] %s C Logger: Log entries will be written to stdout\n", MODULE_NAME);
+        fflush(stdout); // Force flushing of stdout
+    }
+}
+
+const char* ConvertLogLevelToString(LogLevel level) {
+    switch (level) {
+        case DEBUG:   return "DEBUG  ";
+        case INFO:    return "INFO   ";
+        case WARNING: return "WARNING";
+        case SEVERE:  return "SEVERE ";
+        case FATAL:   return "FATAL  ";
+        default:      return "NONE   ";
+    }
+}
+
+LogLevel ConvertStringToLogLevel(const char* str) {
+    char trimmedStr[20] = {0};
+    TrimString(str, trimmedStr, sizeof(trimmedStr));
+    if (strcasecmp(trimmedStr, "DEBUG")   == 0) return DEBUG;
+    if (strcasecmp(trimmedStr, "INFO")    == 0) return INFO;
+    if (strcasecmp(trimmedStr, "WARNING") == 0) return WARNING;
+    if (strcasecmp(trimmedStr, "SEVERE")  == 0) return SEVERE;
+    if (strcasecmp(trimmedStr, "FATAL")   == 0) return FATAL;
+    return NONE;
+}
+
+void SetLoggingFlag(void) {
+    const char* ewtsStr = getenv(EV_EWTS_LOGGING);
+    if (ewtsStr && ewtsStr[0] != '\0') {
+        char trimmedStr[20] = {0};
+        TrimString(ewtsStr, trimmedStr, sizeof(trimmedStr));
+        loggingEnabled = ((strcasecmp(trimmedStr, "ENABLED") == 0))? true:false;
+    }
+    printf("%s C Logger: Logging %s\n", MODULE_NAME, ((loggingEnabled)?"ENABLED":"DISABLED"));
+    fflush(stdout); // Force flushing of stdout
+}
+
+void SetLogLevel(void) {
+    const char* envLogLevel = getenv(EV_MODULE_LOGLEVEL);
+    if (envLogLevel && envLogLevel[0] != '\0') {
+        logLevel = ConvertStringToLogLevel(envLogLevel);
+    }
+    char llStr[10];
+    char msg[100];
+    TrimString(ConvertLogLevelToString(logLevel), llStr, sizeof(llStr));
+    snprintf(msg, sizeof(msg), "C Logger: Log level set to %s\n", llStr);
+    printf("%s %s\n", MODULE_NAME, msg);
+    fflush(stdout); // Force flushing of stdout
+    LogLevel saveLevel = logLevel;
+    logLevel = INFO; // Ensure this INFO message is always logged
+    Log(logLevel, msg);
+    logLevel = saveLevel;
+}
+
+void SetLogPreferences(void) {
+
+    if (!loggerInitialized) {
+        loggerInitialized = true; // Only call this once
+        
+        SetLoggingFlag(); // Based on the environment variable
+        if (loggingEnabled) {
+            SetLogModuleName(); // Set the module name used in log entries
+            SetupLogFile();
+            SetLogLevel();
+            // FOR TESTING ONLY! Uncomment next line to generate test log entries
+            // WriteLogTestMsgs();
+        }
+    }
+}
+
+void TrimToOneNewline(char *str, size_t max_len) {
+    size_t len = strlen(str);
+
+    // Strip trailing whitespace including \n, \r, spaces, tabs
+    while (len > 0 && isspace((unsigned char)str[len - 1])) {
+        str[--len] = '\0';
+    }
+
+    // Ensure room to add a newline
+    if (len + 1 < max_len) {
+        str[len] = '\n';
+        str[len + 1] = '\0';
+    }
+}
+
+LogLevel GetLogLevel(void) {
+    return logLevel;
+}
+
+bool IsLoggingEnabled(void) {
+    return loggingEnabled;
+}
+
+void Log(LogLevel messageLevel, const char* message, ...) {
+    if (!loggerInitialized) SetLogPreferences(); // Initialize logger on first call
+
+    if (loggingEnabled && (messageLevel >= logLevel)) {
+
+        va_list arglist;
+        va_start(arglist, message);
+        va_list arglist_copy;
+        va_copy(arglist_copy, arglist);
+
+        int length = vsnprintf(NULL, 0, message, arglist_copy);
+        va_end(arglist_copy);
+
+        char *buffer = malloc(length + 1);
+        if (!buffer) return; // Always good to check
+
+        vsnprintf(buffer, length + 1, message, arglist);
+        va_end(arglist);
+
+        char timestamp[32];
+        CreateTimestamp(timestamp, sizeof(timestamp), 1, 1);
+
+        char logPrefix[128];
+        snprintf(logPrefix, sizeof(logPrefix), "%s %s %s", timestamp, moduleName, ConvertLogLevelToString(messageLevel));
+
+        TrimToOneNewline(buffer, sizeof(buffer));
+        char *line = strtok(buffer, "\n");
+        if (LogFileReady(true)) {
+            while (line != NULL) {
+                fprintf(logFile, "%s %s\n", logPrefix, line);
+                line = strtok(NULL, "\n");
+            }
+            fflush(logFile);
+        } else {
+            while (line != NULL) {
+                printf("%s %s\n", logPrefix, line);
+                line = strtok(NULL, "\n");
+            }
+            fflush(stdout); // Force flushing of stdout
+        }
+
+        free(buffer);
+    }
+}
+
+void WriteLogTestMsgs() {
+
+    LogLevel savedLogLevel = logLevel;
+    
+    setenv(EV_MODULE_LOGLEVEL, "SEVERE", 1);  Log(SEVERE, "Sample Log for LogLevel::SEVERE");
+    setenv(EV_MODULE_LOGLEVEL, "FATAL", 1);   Log(FATAL, "Sample Log for LogLevel::FATAL");
+    setenv(EV_MODULE_LOGLEVEL, "WARNING", 1); Log(WARNING, "Sample Log for LogLevel::WARNING");
+    setenv(EV_MODULE_LOGLEVEL, "INFO", 1);    Log(INFO, "Sample Log for LogLevel::INFO");
+    setenv(EV_MODULE_LOGLEVEL, "DEBUG", 1);   Log(DEBUG, "Sample Log for LogLevel::DEBUG");
+    
+    const char* multiline_log = 
+        "First line of multiline log:\n"
+        "Second line of multiline log\n"
+        "Third line of multiline log\n"
+        "Fourth line of multiline log";
+    Log(DEBUG, multiline_log);
+    
+    setenv(EV_MODULE_LOGLEVEL, ConvertLogLevelToString(savedLogLevel), 1); 
+}

--- a/src/troute-network/troute/network/logger.h
+++ b/src/troute-network/troute/network/logger.h
@@ -1,0 +1,18 @@
+#ifndef LOGGER_H
+#define LOGGER_H
+
+#include <stdarg.h> // for variable args: va_list
+
+typedef enum {      
+    NONE = 0,
+    DEBUG = 1,
+    INFO = 2,
+    WARNING = 3,
+    SEVERE = 4,
+    FATAL = 5,
+} LogLevel;
+
+// Public Methods
+void Log(LogLevel messageLevel, const char* message, ...);
+
+#endif // LOGGER_H

--- a/src/troute-network/troute/network/reservoirs/hybrid/hybrid_structs.c
+++ b/src/troute-network/troute/network/reservoirs/hybrid/hybrid_structs.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include "logger.h"
 #include "../../reach_structs.h"
 #include <stdio.h>
 /* Hybrid Reservoir Interface */
@@ -57,8 +58,7 @@ init_hybrid_reach(_Reach* reach, int lake_number,
 
     if(water_elevation < -900000000){
       //Equation below is used in wrf-hydro
-      printf("WARNING: HYBRID PERSISTENCE RESERVOIR USING COLDSTART WATER ELEVATION\n");
-      fflush(stdout);
+      Log(WARNING, "HYBRID PERSISTENCE RESERVOIR USING COLDSTART WATER ELEVATION");
       reach->reach.hybrid.water_elevation = orifice_elevation + ((max_depth - orifice_elevation) * initial_fractional_depth);
     }
     else{

--- a/src/troute-network/troute/network/reservoirs/levelpool/levelpool_structs.c
+++ b/src/troute-network/troute/network/reservoirs/levelpool/levelpool_structs.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include "logger.h"
 #include "../../reach_structs.h"
 #include <stdio.h>
 /* Level Pool Reservoir Interface */
@@ -96,8 +97,7 @@ void init_levelpool_reach(_Reach* reach, int lake_number,
 
     if(water_elevation < -900000000){
       //Equation below is used in wrf-hydro
-      printf("WARNING: LEVELPOOL USING COLDSTART WATER ELEVATION\n");
-      fflush(stdout);
+      Log(WARNING, "LEVELPOOL USING COLDSTART WATER ELEVATION");
       reach->reach.lp.water_elevation = orifice_elevation 
           + ((max_depth - orifice_elevation) * initial_fractional_depth);
     }

--- a/src/troute-network/troute/network/reservoirs/rfc/rfc_structs.c
+++ b/src/troute-network/troute/network/reservoirs/rfc/rfc_structs.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include "logger.h"
 #include "../../reach_structs.h"
 #include <stdio.h>
 /* RFC Reservoir Interface */
@@ -51,8 +52,7 @@ void init_rfc_reach(_Reach* reach, int lake_number,
 
     if(water_elevation < -900000000){
       //Equation below is used in wrf-hydro
-      printf("WARNING: RFC RESERVOIR USING COLDSTART WATER ELEVATION\n");
-      fflush(stdout);
+      Log(WARNING, "RFC RESERVOIR USING COLDSTART WATER ELEVATION");
       reach->reach.rfc.water_elevation = orifice_elevation + ((max_depth - orifice_elevation) * initial_fractional_depth);
     }
     else{


### PR DESCRIPTION
The T-Route Python code also calls some C modules. These modules were not logging their message to the log file but instead were writing them to stdout. Added the ability to write entries to the EWTS log file.

## Additions

- Added logger.h and logger.c to the t-route network directory containing the C code.

## Changes

- Update the setup.py file package and extension entries to reference the new logger files and build the logger.c files, ensuring the appropriate include directory was specified.
- Updated the logger.c to write to stdout when it is using the log file defined by the env var set by T-Route Python logger.
- Updated the logger.c code to add an entry to the ngen.log for the C Logger log level, which will always be the same as T-Route Python log level.
- This will only setup the C logger when there is a waterbody.
- Unable to test specifically for RFC specific gage since I am unaware of one, but the logger code is the same so there should not be an issue if and when an RFC gage is tested with a waterbody.
- The Hybrid version was commented out but added the necessary statements when the time comes to use it.

## Testing

1. Tested using the CNF gage, which has a waterbody, to ensure the printf message was being logged in ngen.log instead of printed to stdout.
2. Tested using 12114500 gage, which does not have a waterbody, to ensure it works in that case as well.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
