### PR TITLE
Use named logger for t-route. Hardcoded for now.

### DIFF
--- a/src/model_DAforcing.py
+++ b/src/model_DAforcing.py
@@ -19,7 +19,7 @@ from troute.routing.fast_reach.reservoir_RFC_da import _validate_RFC_data
 import netCDF4
 from nwm_routing.log_level_set import log_level_set
 from troute.config import Config
-LOG = logging.getLogger('')
+LOG = logging.getLogger('T-Route')
 
 class DAforcing_model():
 

--- a/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
+++ b/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
@@ -17,7 +17,7 @@ import nwm_routing.__main__ as nwm_routing
 from nwm_routing.output import nwm_output_generator
 from nwm_routing.log_level_set import log_level_set
 
-LOG = logging.getLogger("")
+LOG = logging.getLogger('T-Route')
 
 
 class Model:

--- a/src/troute-network/troute/AbstractNetwork.py
+++ b/src/troute-network/troute/AbstractNetwork.py
@@ -18,7 +18,7 @@ from troute.nhd_network_utilities_v02 import organize_independent_networks
 import troute.nhd_io as nhd_io 
 from .AbstractRouting import MCOnly, MCwithDiffusive, MCwithDiffusiveNatlXSectionNonRefactored, MCwithDiffusiveNatlXSectionRefactored
 
-LOG = logging.getLogger('')
+LOG = logging.getLogger('T-Route')
 
 class AbstractNetwork(ABC):
     """

--- a/src/troute-network/troute/AbstractRouting.py
+++ b/src/troute-network/troute/AbstractRouting.py
@@ -9,7 +9,7 @@ from itertools import chain
 from troute.nhd_network import reverse_network, reachable
 from troute.nhd_network_utilities_v02 import organize_independent_networks, build_refac_connections
 
-LOG = logging.getLogger('')
+LOG = logging.getLogger('T-Route')
 
 def read_diffusive_domain(domain_file):
     '''

--- a/src/troute-network/troute/DataAssimilation.py
+++ b/src/troute-network/troute/DataAssimilation.py
@@ -11,7 +11,7 @@ import re
 import time
 import logging
 
-LOG = logging.getLogger('')
+LOG = logging.getLogger('T-Route')
 from troute.routing.fast_reach.reservoir_RFC_da import _validate_RFC_data
 
 from troute.network import bmi_array2df as a2df

--- a/src/troute-network/troute/NHDNetwork.py
+++ b/src/troute-network/troute/NHDNetwork.py
@@ -12,7 +12,7 @@ import pyarrow.parquet as pq
 from troute.nhd_network import reverse_dict, extract_waterbody_connections, gage_mapping, extract_connections, replace_waterbodies_connections
 
 import logging
-LOG = logging.getLogger('')
+LOG = logging.getLogger('T-Route')
 
 __showtiming__ = True #FIXME pass flag
 __verbose__ = True #FIXME pass verbosity

--- a/src/troute-network/troute/hyfeature_network_utilities.py
+++ b/src/troute-network/troute/hyfeature_network_utilities.py
@@ -15,7 +15,7 @@ import pyarrow.parquet as pq
 import troute.nhd_io as nhd_io
 
 
-LOG = logging.getLogger('')
+LOG = logging.getLogger('T-Route')
 
 
 def build_da_sets(da_params, run_sets, t0):

--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -20,7 +20,7 @@ from datetime import datetime, timedelta
 
 from troute.nhd_network import reverse_dict
 
-LOG = logging.getLogger('')
+LOG = logging.getLogger('T-Route')
 
 def read_netcdf(geo_file_path):
     '''

--- a/src/troute-network/troute/nhd_network_utilities_v02.py
+++ b/src/troute-network/troute/nhd_network_utilities_v02.py
@@ -12,7 +12,7 @@ from joblib import delayed, Parallel
 import troute.nhd_io as nhd_io
 import troute.nhd_network as nhd_network
 
-LOG = logging.getLogger('')
+LOG = logging.getLogger('T-Route')
 
 def build_connections(supernetwork_parameters):
     '''

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -31,7 +31,7 @@ import troute.hyfeature_network_utilities as hnu
 import sys
 
 
-LOG = logging.getLogger('')
+LOG = logging.getLogger('T-Route')
 
 '''
 High level orchestration of ngen t-route simulations for NWM application

--- a/src/troute-nwm/src/nwm_routing/input.py
+++ b/src/troute-nwm/src/nwm_routing/input.py
@@ -9,7 +9,7 @@ import troute.nhd_network_utilities_v02 as nnu
 from .log_level_set import log_level_set
 from troute.config import Config
 
-LOG = logging.getLogger('')
+LOG = logging.getLogger('T-Route')
 
 def _input_handler_v04(args):
     '''
@@ -120,7 +120,7 @@ def _input_handler_v03(args):
 
     # configure python logger
     log_level_set(log_parameters)
-    LOG = logging.getLogger('')
+    LOG = logging.getLogger('T-Route')
 
     # if log level is at or below DEBUG, then check user inputs
     if LOG.isEnabledFor(logging.DEBUG):

--- a/src/troute-nwm/src/nwm_routing/log_level_set.py
+++ b/src/troute-nwm/src/nwm_routing/log_level_set.py
@@ -1,10 +1,11 @@
-import logging
-import sys   
-from datetime import datetime, timezone
-import os
-import time
-import getpass
+"""Logging module to integrate with NGEN"""
 
+import getpass
+import logging
+import os
+import sys   
+import time
+from datetime import datetime, timezone
 
 MODULE_NAME           = "T-Route";
 LOG_DIR_NGENCERF      = "/ngencerf/data";       # ngenCERF log directory string if environement var empty.
@@ -19,6 +20,8 @@ EV_MODULE_LOGLEVEL    = "TROUTE_LOGLEVEL";      # This modules log level
 EV_MODULE_LOGFILEPATH = "TROUTE_LOGFILEPATH";   # This modules log full log filename
 
 class CustomFormatter(logging.Formatter):
+    """A custom formatting class for logging"""
+
     LEVEL_NAME_MAP = {
         logging.DEBUG: "DEBUG",
         logging.INFO: "INFO",
@@ -26,6 +29,21 @@ class CustomFormatter(logging.Formatter):
         logging.ERROR: "SEVERE",
         logging.CRITICAL: "FATAL"
     }
+ 
+    # Apply custom formatter (UTC timestamps applied only to this formatter)
+    def converter(self, timestamp):
+        """Override time converter to return UTC time tuple"""
+        return time.gmtime(timestamp)
+
+    def formatTime(self, record, datefmt=None):
+        """Use our UTC converter"""
+        ct = self.converter(record.created)
+        if datefmt:
+            s = time.strftime(datefmt, ct)
+        else:
+            t = time.strftime("%Y-%m-%d %H:%M:%S", ct)
+            s = f"{t},{int(record.msecs):03d}"
+        return s
 
     def format(self, record):
         original_levelname = record.levelname
@@ -63,6 +81,7 @@ def get_log_file_path():
         if ngenEnvVar:
             logFilePath = ngenEnvVar
         else:
+            print(f"Module {MODULE_NAME} Env var {EV_NGEN_LOGFILEPATH} not found. Creating default log name.")
             appendEntries = False
             if os.path.isdir(LOG_DIR_NGENCERF):
                 logFileDir = LOG_DIR_NGENCERF + DS + LOG_DIR_DEFAULT
@@ -73,12 +92,12 @@ def get_log_file_path():
                 # Set full log path
                 username = getpass.getuser()
                 if username:
-                    logFieDir = logFieDir + DS + username
+                    logFileDir = logFileDir + DS + username
                 else:
                     logFileDir = logFileDir + DS + create_timestamp(True)
                 # Create directory
-                with os.makedirs(logFileDir, exist_ok=True):
-                    logFilePath = logFileDir + DS + MODULE_NAME + "_" + create_timestamp() + "." + LOG_FILE_EXT
+                os.makedirs(logFileDir, exist_ok=True)
+                logFilePath = logFileDir + DS + MODULE_NAME + "_" + create_timestamp() + "." + LOG_FILE_EXT
             except Exception as e:
                 logFilePath = ""
 
@@ -91,12 +110,12 @@ def get_log_file_path():
                 logFile = open(logFilePath, "w")
             if (moduleLogEnvExists == False):
                 os.environ[EV_MODULE_LOGFILEPATH] = logFilePath 
-                print(f"Module {MODULE_NAME} Log File: {logFilePath}")
+                print(f"Module {MODULE_NAME} Log File: {logFilePath}", flush=True)
         else:
             raise IOError
     except:
-        print(f"Unable to open log file for {MODULE_NAME}: {logFilePath}")
-        print(f"Log entries will be writen to stdout")
+        print(f"Module {MODULE_NAME} Unable to open log file: {logFilePath}", flush=True)
+        print(f"Module {MODULE_NAME} Log entries will be writen to stdout", flush=True)
 
     return logFilePath, appendEntries
     
@@ -114,6 +133,18 @@ def translate_ngwpc_log_level(ngwpc_log_level: str) -> str:
     elif (ll == "FATAL"):
         return "CRITICAL"
     return ll
+
+def force_info(handler, logger, msg, *args):
+    record = logger.makeRecord(
+        logger.name,
+        logging.INFO,
+        __file__,
+        0,
+        msg,
+        args,
+        None,
+    )
+    handler.emit(record)
 
 def log_level_set(input_parameters):
     '''
@@ -140,27 +171,37 @@ def log_level_set(input_parameters):
           it is only opened once for each ngen run (vs for each catchment)
 
     See also https://docs.python.org/3/library/logging.html
-    
+
     '''
+    
+    # Use a named logger to ensure entries are identified as this
+    # MODULE_NAME and are not miss-identfied in the ngen log.
+    logger = logging.getLogger(MODULE_NAME)
+    if getattr(logger, "_initialized", False):
+        return  # logger already initialized, nothing else to do
+
     loggingEnabled = True
     moduleEnvVar = os.getenv(EV_EWTS_LOGGING, "")
     if moduleEnvVar:
         if (moduleEnvVar == "DISABLED"):
             loggingEnabled = False
-
-    if (loggingEnabled == False):
-        print(f"Module {MODULE_NAME} Logging DISABLED")
-        logging.disable(logging.CRITICAL)  # Disables all logs at CRITICAL and below (i.e., everything)
     else:
-        print(f"Module {MODULE_NAME} Logging ENABLED")
-
-        # Get the log file name from env var or a default 
+        print(f"Module {MODULE_NAME} Env var {EV_EWTS_LOGGING} not found. Using logging defaults.")
+ 
+    if (loggingEnabled == False):
+        print(f"Module {MODULE_NAME} Logging DISABLED", flush=True)
+        logger.disabled = True  # Disables all logs at CRITICAL and below (i.e., everything)
+    else:
+        print(f"Module {MODULE_NAME} Logging ENABLED", flush=True)
+ 
+        # Get the log file name from env var or a default
         logFilePath, appendEntries = get_log_file_path()
         if (logFilePath):
             # Set the open mode
             openMode = 'a' if appendEntries else 'w'
             handler = logging.FileHandler(logFilePath, mode=openMode)
         else:
+            print(f"Module {MODULE_NAME} unable to create log file. Using stdout.")
             handler = logging.StreamHandler(sys.stdout)
 
         # Get the log level from env var or a default
@@ -170,32 +211,19 @@ def log_level_set(input_parameters):
         formatted_module = MODULE_NAME.upper().ljust(LOG_MODULE_NAME_LEN)[:LOG_MODULE_NAME_LEN]
 
         # Apply custom formatter
-        formatted_module = MODULE_NAME.upper().ljust(LOG_MODULE_NAME_LEN)[:LOG_MODULE_NAME_LEN]
         formatter = CustomFormatter(
             fmt=f"%(asctime)s.%(msecs)03d {formatted_module} %(levelname_padded)s %(message)s",
             datefmt="%Y-%m-%dT%H:%M:%S"
         )
         handler.setFormatter(formatter)
+ 
+        # Setup logger
+        logger.handlers.clear()  # Clear any default handlers
+        logger.setLevel(translate_ngwpc_log_level(log_level))
+        logger.addHandler(handler)
+ 
+        # Write log level INFO message to log regradless of the actual log level
+        force_info(handler, logger, "Log level set to %s", log_level)
+        print(f"Module {MODULE_NAME} Log Level set to {log_level}", flush=True)
 
-        # Setup root logger
-        logging.getLogger().handlers.clear()  # Clear any default handlers
-        logging.getLogger().setLevel(translate_ngwpc_log_level(log_level))
-        logging.getLogger().addHandler(handler)
-
-        # Ensure UTC timestamps
-        logging.Formatter.converter = time.gmtime
-
-        # Save the current log level
-        current_level = logging.getLogger().getEffectiveLevel()
-
-        try:
-            # Temporarily set log level to INFO
-            logging.getLogger().setLevel(logging.INFO)
-            
-            # Log the message at INFO level
-            logging.info(f"Log level set to {log_level}")
-            print(f"Module {MODULE_NAME} Log Level set to {log_level}")
-        finally:
-            # Restore the original log level
-            logging.getLogger().setLevel(current_level)
-    
+    logger._initialized = True

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -7,7 +7,7 @@ import troute.nhd_io as nhd_io
 from build_tests import parity_check
 import logging
 
-LOG = logging.getLogger('')
+LOG = logging.getLogger('T-Route')
 
 def _reindex_lake_to_link_id(target_df, crosswalk):
     '''

--- a/src/troute-nwm/src/nwm_routing/preprocess.py
+++ b/src/troute-nwm/src/nwm_routing/preprocess.py
@@ -12,7 +12,7 @@ import troute.nhd_network_utilities_v02 as nnu
 import troute.nhd_network as nhd_network
 import troute.nhd_io as nhd_io
 
-LOG = logging.getLogger('')
+LOG = logging.getLogger('T-Route')
 
 def _reindex_link_to_lake_id(target_df, crosswalk):
     '''

--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -16,7 +16,7 @@ from troute.routing.fast_reach import diffusive
 
 import logging
 
-LOG = logging.getLogger('')
+LOG = logging.getLogger('T-Route')
 
 _compute_func_map = defaultdict(
     compute_network_structured,

--- a/src/troute-routing/troute/routing/fast_reach/reservoir_GL_da.py
+++ b/src/troute-routing/troute/routing/fast_reach/reservoir_GL_da.py
@@ -1,7 +1,7 @@
 import numpy as np
 import logging
 from datetime import datetime, timedelta
-LOG = logging.getLogger('')
+LOG = logging.getLogger('T-Route')
 
 def great_lakes_da(
     gage_obs,

--- a/src/troute-routing/troute/routing/fast_reach/reservoir_hybrid_da.py
+++ b/src/troute-routing/troute/routing/fast_reach/reservoir_hybrid_da.py
@@ -1,6 +1,6 @@
 import numpy as np
 import logging
-LOG = logging.getLogger('')
+LOG = logging.getLogger('T-Route')
 
 def _modify_for_projected_storage(
     inflow, 


### PR DESCRIPTION
To be consistent with other Python loggers, updates have been made to use a named logger instead of the root logger as well as making the code consistent. Also fixed a typo for the log file name that would have created a valid name but not the expected one.

## Additions

- Added a method to for logging a "INFO" level message, regardless of the debug level. This is used only to record what the log level is set to in the log files.
- Use a flag set in the logger module for the named logger to indicate if it has already been initialized.

## Removals

-

## Changes

- Updated the calls to get_logger to include the name of the logger.
- Cleaned up typo's
- Updated print statements when configuring the logger.
- Moved some code within the log_level_set to be logically grouped and consistent with other program python modules.

## Testing

1. Ran standalone with several different formulations verifying the ngen.log file was created and the t-route entries were properly entered in the log.
2. Built the docker containers in AWS Workspace and ran a calibration with validation, verifying the ngen.log file was created and the t-route entries were properly entered in the log.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) 
