### PR TITLE
Coastal coupling data load accessible outside assemble_forcings

### DIFF
--- a/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
+++ b/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
@@ -65,6 +65,7 @@ class Model:
             )
         else:
             raise Exception("Supernetwork network type must be HYFeaturesNetwork or NHDNetwork")
+        self._network.assemble_coastal_coupling_data()
         network_creation_time = time.time() - network_start_time
 
         # Data data assimilation

--- a/src/troute-network/troute/AbstractNetwork.py
+++ b/src/troute-network/troute/AbstractNetwork.py
@@ -136,7 +136,9 @@ class AbstractNetwork(ABC):
             "lateral inflow DataFrame creation complete in %s seconds." \
                 % (time.time() - start_time)
                 )
+        self.assemble_coastal_coupling_data()
 
+    def assemble_coastal_coupling_data(self):
         #---------------------------------------------------------------------
         # Assemble coastal coupling data [WIP]
         #---------------------------------------------------------------------


### PR DESCRIPTION
Copied from PR #70 that was merged into `development` when it should have been merged into `ngwpc-candidate`. 

Coastal coupling data was previously loaded by `AbstractNetwork.assemble_forcings`. To allow the t-route configuration to be cross-compatible with calling t-route as a python process, the coastal coupling loading has been moved to a new method specifically for it, and `assemble_forcings` calls that method. This gives the BMI the ability to load the coastal coupling data without triggering other IO operations that the network would run during `assemble_forcings`.

## Additions

- `AbstractNetwork.assemble_coastal_coupling_data` method for loading the coastal coupling data separate from other data loading handled in `assemble_forcings`
- A call to `assemble_coastal_coupling_data` at the end of `assemble_forcings`
- A call to `assemble_coastal_coupling_data` after the BMI creates its network object

## Removals

- Any logic for assembling the coastal coupling data directly in `aseemble_forcings`


## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
