### PR TITLE
Add Serialization Messaging (NGWPC-9482)

### DIFF
--- a/src/troute-bmi/src/troute_nwm_bmi/troute_bmi.py
+++ b/src/troute-bmi/src/troute_nwm_bmi/troute_bmi.py
@@ -1,9 +1,14 @@
 """Basic Model Interface implementation for NGEN t-route."""
 from __future__ import annotations
+import pickle
+import typing
 import numpy as np
 from bmipy import Bmi
 
 from .troute_model import Model
+
+if typing.TYPE_CHECKING:
+    from numpy.typing import NDArray
 
 _COUNT_SUFFIX = "__count"
 
@@ -39,28 +44,28 @@ _INPUT_VAR_NAMES = [
 
 class BmiTroute(Bmi):
     _model: Model
-    _values: dict[str, np.ndarray]
 
     def __init__(self):
         super().__init__()
-        self._values = {
+        self._values: dict[str, NDArray] = {
             "land_surface_water_source__id": np.zeros(0, dtype=np.intc),
             "land_surface_water_source__id" + _COUNT_SUFFIX: np.zeros(1, dtype=np.int64),
-            "land_surface_water_source__volume_flow_rate": np.zeros(0, dtype=float),
+            "land_surface_water_source__volume_flow_rate": np.zeros(0, dtype=np.double),
             "land_surface_water_source__volume_flow_rate" + _COUNT_SUFFIX: np.zeros(1, dtype=np.int64),
             "upstream_id": np.zeros(0, dtype=int),
-            "channel_water__id": np.zeros([], dtype=np.int64),
-            "channel_exit_water_x-section__volume_flow_rate": np.zeros([], dtype=np.float64),
-            "channel_water_flow__speed": np.zeros([], dtype=np.float64),
-            "channel_water__mean_depth": np.zeros([], dtype=np.float64),
-            "lake_water__id": np.zeros([], dtype=np.int64),
-            "lake_water~incoming__volume_flow_rate": np.zeros([], dtype=np.float64),
-            "lake_water~outgoing__volume_flow_rate": np.zeros([], dtype=np.float64),
-            "lake_surface__elevation": np.zeros([], dtype=np.float64),
+            "channel_water__id": np.zeros(0, dtype=np.int64),
+            "channel_exit_water_x-section__volume_flow_rate": np.zeros(0, dtype=np.float32),
+            "channel_water_flow__speed": np.zeros(0, dtype=np.float32),
+            "channel_water__mean_depth": np.zeros(0, dtype=np.float32),
+            "lake_water__id": np.zeros(0, dtype=np.int64),
+            "lake_water~incoming__volume_flow_rate": np.zeros(0, dtype=np.float32),
+            "lake_water~outgoing__volume_flow_rate": np.zeros(0, dtype=np.float32),
+            "lake_surface__elevation": np.zeros(0, dtype=np.float32),
         }
         self._var_loc = "node"
         self._var_grid_id = 0
         self._time_units = "s"
+        self._free_serialized()
 
     def initialize(self, bmi_cfg_file):
         self._model = Model(bmi_cfg_file)
@@ -83,12 +88,25 @@ class BmiTroute(Bmi):
         src : array_like
             Array of new values.
         """
+        if var_name == "serialization_create":
+            self._serialize()
+            return
+        elif var_name == "serialization_state":
+            self._deserialize(src)
+            return
+        elif var_name == "serialization_free":
+            self._free_serialized()
+            return
         # special case for changing data size 
         if var_name.endswith(_COUNT_SUFFIX):
             source_var_name = var_name[:-len(_COUNT_SUFFIX)]
             source = self._values.get(source_var_name)
             self._values[source_var_name] = np.resize(source, int(src[0]))
-        self._values[var_name][:] = src
+        var = self._values[var_name]
+        if len(src) == len(var):
+            var[:] = src
+        else:
+            self._values[var_name] = np.array(src, dtype=var.dtype)
 
     def get_value(self, var_name: str):
         """Copy of values.
@@ -101,7 +119,7 @@ class BmiTroute(Bmi):
         output_df : pd.DataFrame
             Copy of values.
         """
-        return np.copy(self._values[var_name])
+        return np.copy(self.get_value_ptr(var_name))
 
     def get_value_ptr(self, var_name: str):
         """Reference to values.
@@ -114,6 +132,10 @@ class BmiTroute(Bmi):
         array_like
             Value array.
         """
+        if var_name == "serialiation_state":
+            return self._serialized
+        if var_name == "serialization_size" or var_name == "serialization_create":
+            return self._serialized_size
         return self._values[var_name]
 
     def get_start_time(self):
@@ -153,7 +175,7 @@ class BmiTroute(Bmi):
             self.update()
         self._model.dt = time_step
 
-    def get_var_type(self, var_name):
+    def get_var_type(self, var_name: str):
         """Data type of variable.
         Parameters
         ----------
@@ -164,7 +186,9 @@ class BmiTroute(Bmi):
         str
             Data type.
         """
-        return str(self.get_value(var_name).dtype)
+        if var_name == "serialization_free":
+            return np.dtype(np.intc).name
+        return self.get_value_ptr(var_name).dtype.name
 
     def get_var_units(self, var_name: str):
         """Get units of variable.
@@ -179,7 +203,7 @@ class BmiTroute(Bmi):
         """
         return _VAR_NAME_UNITS_MAP[var_name][1]
 
-    def get_var_nbytes(self, var_name):
+    def get_var_nbytes(self, var_name: str):
         """Get units of variable.
         Parameters
         ----------
@@ -190,7 +214,11 @@ class BmiTroute(Bmi):
         int
             Size of data array in bytes.
         """
-        return self.get_value(var_name).nbytes
+        if var_name == "serialization_state":
+            return int(self._serialized_size[0])
+        if var_name == "serialization_free":
+            return np.dtype(np.intc).itemsize
+        return self.get_value_ptr(var_name).nbytes
 
     def get_var_itemsize(self, name):
         return np.dtype(self.get_var_type(name)).itemsize
@@ -344,3 +372,25 @@ class BmiTroute(Bmi):
 
     def get_grid_z(self, grid, z):
         raise NotImplementedError("get_grid_z")
+
+    def _serialize(self):
+        data = {
+            "values": self._values,
+            "model": self._model.create_state(),
+        }
+        # HIGHEST_PROTOCOL recommended for pickling pandas DataFrames
+        serialized = pickle.dumps(data, pickle.HIGHEST_PROTOCOL)
+        self._serialized = np.array(
+            bytearray(serialized), dtype=self._serialized.dtype
+        )
+        self._serialized_size[0] = len(self._serialized)
+
+    def _deserialize(self, data):
+        deserialized = pickle.loads(bytes(data))
+        self._values = deserialized["values"]
+        self._model.load_state(deserialized["model"])
+        self._free_serialized()
+
+    def _free_serialized(self):
+        self._serialized = np.zeros(0, dtype=np.uint8)
+        self._serialized_size = np.zeros(1, dtype=np.uint64)

--- a/src/troute-bmi/src/troute_nwm_bmi/troute_bmi.py
+++ b/src/troute-bmi/src/troute_nwm_bmi/troute_bmi.py
@@ -10,7 +10,6 @@ from .troute_model import Model
 if typing.TYPE_CHECKING:
     from numpy.typing import NDArray
 
-_COUNT_SUFFIX = "__count"
 
 _VAR_NAME_UNITS_MAP = {
     'land_surface_water_source__volume_flow_rate': ['streamflow_cms', 'm3 s-1'],
@@ -35,9 +34,7 @@ _OUTPUT_VAR_NAMES = [
 
 _INPUT_VAR_NAMES = [
     "land_surface_water_source__id",
-    "land_surface_water_source__id" + _COUNT_SUFFIX,
     "land_surface_water_source__volume_flow_rate",
-    "land_surface_water_source__volume_flow_rate" + _COUNT_SUFFIX,
     "upstream_id",
 ]
 
@@ -49,9 +46,7 @@ class BmiTroute(Bmi):
         super().__init__()
         self._values: dict[str, NDArray] = {
             "land_surface_water_source__id": np.zeros(0, dtype=np.intc),
-            "land_surface_water_source__id" + _COUNT_SUFFIX: np.zeros(1, dtype=np.int64),
             "land_surface_water_source__volume_flow_rate": np.zeros(0, dtype=np.double),
-            "land_surface_water_source__volume_flow_rate" + _COUNT_SUFFIX: np.zeros(1, dtype=np.int64),
             "upstream_id": np.zeros(0, dtype=int),
             "channel_water__id": np.zeros(0, dtype=np.int64),
             "channel_exit_water_x-section__volume_flow_rate": np.zeros(0, dtype=np.float32),
@@ -71,10 +66,13 @@ class BmiTroute(Bmi):
         self._model = Model(bmi_cfg_file)
 
     def update(self):
-        self._model.update(self._values)
-    
+        self._model.run(self._values)
+        # clear current flow values
+        dtype = self._values["land_surface_water_source__volume_flow_rate"].dtype
+        self._values["land_surface_water_source__volume_flow_rate"] = np.zeros(0, dtype=dtype)
+
     def update_until(self, time):
-        while self._model._time < time:
+        if self._model.time < time:
             self.update()
 
     def set_value(self, var_name: str, src):
@@ -97,11 +95,9 @@ class BmiTroute(Bmi):
         elif var_name == "serialization_free":
             self._free_serialized()
             return
-        # special case for changing data size 
-        if var_name.endswith(_COUNT_SUFFIX):
-            source_var_name = var_name[:-len(_COUNT_SUFFIX)]
-            source = self._values.get(source_var_name)
-            self._values[source_var_name] = np.resize(source, int(src[0]))
+        elif var_name == "reset_time":
+            self._model.reset_time()
+            return
         var = self._values[var_name]
         if len(src) == len(var):
             var[:] = src
@@ -132,7 +128,7 @@ class BmiTroute(Bmi):
         array_like
             Value array.
         """
-        if var_name == "serialiation_state":
+        if var_name == "serialization_state":
             return self._serialized
         if var_name == "serialization_size" or var_name == "serialization_create":
             return self._serialized_size
@@ -158,7 +154,7 @@ class BmiTroute(Bmi):
     def finalize(self):
         """Finalize model."""
         if self._model is not None:
-            self._model.run(self._values)
+            self._model.log_times()
             self._model = None
 
     # BMI functions that are not being used yet...
@@ -188,6 +184,8 @@ class BmiTroute(Bmi):
         """
         if var_name == "serialization_free":
             return np.dtype(np.intc).name
+        if var_name == "reset_time":
+            return np.dtype(np.double).name
         return self.get_value_ptr(var_name).dtype.name
 
     def get_var_units(self, var_name: str):
@@ -216,8 +214,8 @@ class BmiTroute(Bmi):
         """
         if var_name == "serialization_state":
             return int(self._serialized_size[0])
-        if var_name == "serialization_free":
-            return np.dtype(np.intc).itemsize
+        if var_name == "serialization_free" or var_name == "reset_time":
+            return np.dtype(self.get_var_type(var_name)).itemsize
         return self.get_value_ptr(var_name).nbytes
 
     def get_var_itemsize(self, name):

--- a/src/troute-bmi/src/troute_nwm_bmi/troute_bmi.py
+++ b/src/troute-bmi/src/troute_nwm_bmi/troute_bmi.py
@@ -9,13 +9,30 @@ _COUNT_SUFFIX = "__count"
 
 _VAR_NAME_UNITS_MAP = {
     'land_surface_water_source__volume_flow_rate': ['streamflow_cms', 'm3 s-1'],
+    'channel_exit_water_x-section__volume_flow_rate': ['streamflow_cms', 'm3 s-1'],
+    'channel_water_flow__speed': ['streamflow_ms', 'm s-1'],
+    'channel_water__mean_depth': ['streamflow_m', 'm'],
+    'lake_water~incoming__volume_flow_rate': ['waterbody_cms', 'm3 s-1'],
+    'lake_water~outgoing__volume_flow_rate': ['waterbody_cms', 'm3 s-1'],
+    'lake_surface__elevation': ['waterbody_m', 'm'],
 }
 
-_OUTPUT_VAR_NAMES = []
+_OUTPUT_VAR_NAMES = [
+    "channel_water__id",
+    "channel_exit_water_x-section__volume_flow_rate",
+    "channel_water_flow__speed",
+    "channel_water__mean_depth",
+    "lake_water__id",
+    "lake_water~incoming__volume_flow_rate",
+    "lake_water~outgoing__volume_flow_rate",
+    "lake_surface__elevation"
+]
 
 _INPUT_VAR_NAMES = [
     "land_surface_water_source__id",
+    "land_surface_water_source__id" + _COUNT_SUFFIX,
     "land_surface_water_source__volume_flow_rate",
+    "land_surface_water_source__volume_flow_rate" + _COUNT_SUFFIX,
     "upstream_id",
 ]
 
@@ -32,12 +49,18 @@ class BmiTroute(Bmi):
             "land_surface_water_source__volume_flow_rate": np.zeros(0, dtype=float),
             "land_surface_water_source__volume_flow_rate" + _COUNT_SUFFIX: np.zeros(1, dtype=np.int64),
             "upstream_id": np.zeros(0, dtype=int),
+            "channel_water__id": np.zeros([], dtype=np.int64),
+            "channel_exit_water_x-section__volume_flow_rate": np.zeros([], dtype=np.float64),
+            "channel_water_flow__speed": np.zeros([], dtype=np.float64),
+            "channel_water__mean_depth": np.zeros([], dtype=np.float64),
+            "lake_water__id": np.zeros([], dtype=np.int64),
+            "lake_water~incoming__volume_flow_rate": np.zeros([], dtype=np.float64),
+            "lake_water~outgoing__volume_flow_rate": np.zeros([], dtype=np.float64),
+            "lake_surface__elevation": np.zeros([], dtype=np.float64),
         }
         self._var_loc = "node"
         self._var_grid_id = 0
         self._time_units = "s"
-        self._start_time = 0.0
-        self._end_time = np.finfo("d").max
 
     def initialize(self, bmi_cfg_file):
         self._model = Model(bmi_cfg_file)
@@ -95,17 +118,17 @@ class BmiTroute(Bmi):
 
     def get_start_time(self):
         """Start time of model."""
-        return self._start_time
+        return 0.0
 
     def get_end_time(self):
         """End time of model."""
-        return self._end_time
+        return self._model.ngen_dt * (self._model.nts - 1)
 
     def get_current_time(self):
         return self._model.time
 
     def get_time_step(self):
-        return self._model.dt
+        return self._model.ngen_dt
 
     def get_time_units(self):
         return self._time_units

--- a/src/troute-bmi/src/troute_nwm_bmi/troute_bmi.py
+++ b/src/troute-bmi/src/troute_nwm_bmi/troute_bmi.py
@@ -36,6 +36,7 @@ _INPUT_VAR_NAMES = [
     "land_surface_water_source__id",
     "land_surface_water_source__volume_flow_rate",
     "upstream_id",
+    "ngen_dt",
 ]
 
 
@@ -45,6 +46,7 @@ class BmiTroute(Bmi):
     def __init__(self):
         super().__init__()
         self._values: dict[str, NDArray] = {
+            "ngen_dt": np.array([-1], dtype=np.intc),
             "land_surface_water_source__id": np.zeros(0, dtype=np.intc),
             "land_surface_water_source__volume_flow_rate": np.zeros(0, dtype=np.double),
             "upstream_id": np.zeros(0, dtype=int),

--- a/src/troute-bmi/src/troute_nwm_bmi/troute_bmi.py
+++ b/src/troute-bmi/src/troute_nwm_bmi/troute_bmi.py
@@ -59,13 +59,10 @@ class BmiTroute(Bmi):
             "lake_water~outgoing__volume_flow_rate": np.zeros(0, dtype=np.float32),
             "lake_surface__elevation": np.zeros(0, dtype=np.float32),
         }
-        self._var_loc = "node"
-        self._var_grid_id = 0
-        self._time_units = "s"
         self._free_serialized()
 
     def initialize(self, bmi_cfg_file):
-        self._model = Model(bmi_cfg_file)
+        self._model = Model(bmi_cfg_file, self.get_start_time())
 
     def update(self):
         self._model.run(self._values)
@@ -142,16 +139,16 @@ class BmiTroute(Bmi):
 
     def get_end_time(self):
         """End time of model."""
-        return self._model.ngen_dt * (self._model.nts - 1)
+        return float(self._model.ngen_dt(self._values) * (self._model.nts - 1))
 
     def get_current_time(self):
         return self._model.time
 
     def get_time_step(self):
-        return self._model.ngen_dt
+        return self._model.ngen_dt(self._values)
 
     def get_time_units(self):
-        return self._time_units
+        return "s"
 
     def finalize(self):
         """Finalize model."""
@@ -221,10 +218,11 @@ class BmiTroute(Bmi):
         return self.get_value_ptr(var_name).nbytes
 
     def get_var_itemsize(self, name):
+        # needs to go through `get_var_type` for names without stored values
         return np.dtype(self.get_var_type(name)).itemsize
 
     def get_var_location(self, name):
-        return self._var_loc[name]
+        return "node"
 
     def get_var_grid(self, var_name):
         """Grid id for a variable.

--- a/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
+++ b/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
@@ -247,7 +247,7 @@ class Model:
         self._timings["output_time"] = time.time() - output_start_time
 
         # update time as (ngen dt in seconds) * (number of steps processed)
-        self._time += self.ngen_dt * qlats.shape[1]
+        self._time += self._ngen_dt(bmi_values) * qlats.shape[1]
 
     def log_times(self):
         if self.show_timing:
@@ -375,12 +375,16 @@ class Model:
     def qts_subdivisions(self) -> int:
         return self.forcing_parameters["qts_subdivisions"]
 
-    @property
-    def ngen_dt(self) -> int:
+    def _ngen_dt(self, bmi_values: dict[str, NDArray]) -> int:
+        if ("ngen_dt" in bmi_values) and (len(bmi_values["ngen_dt"]) == 1):
+            dt = bmi_values["ngen_dt"][0]
+            if dt > 0:
+                return int(dt)
+        # backup if NGEN's delta time was not explicitly set
         return int(self.dt * self.qts_subdivisions)
 
     def _construct_qlats(self, bmi_values: dict[str, NDArray]):
-        dt = self.ngen_dt
+        dt = self._ngen_dt(bmi_values)
         step_time = self._network.t0
         water_source_ids = bmi_values["land_surface_water_source__id"]
         water_source_values = bmi_values["land_surface_water_source__volume_flow_rate"]

--- a/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
+++ b/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
@@ -29,7 +29,6 @@ class Model:
     dt: int
 
     def __init__(self, config_file: str):
-        self._main_start_time = time.time()
         self._time = 0.0
 
         with open(config_file) as reader:
@@ -410,7 +409,7 @@ class Model:
             seconds = round(self._timings[key], 2)
             percent = round(self._timings[key] / process_time * 100, 2)
             LOG.info(f"{title}: {seconds} secs, {percent} %")
-        process_time = time.time() - self._main_start_time
+        process_time = sum(self._timings.values())
         LOG.debug(f"Processes complete in {process_time} seconds.")
         LOG.info('************ TIMING SUMMARY ************')
         LOG.info('----------------------------------------')
@@ -418,5 +417,4 @@ class Model:
         sec_and_per("Forcing array construction", "forcing_time")
         sec_and_per("Routing computations", "route_time")
         sec_and_per("Output writing", "output_time")
-        total_execution_time = round(sum(self._timings.values()), 2)
-        LOG.info(f"Total execution time: {total_execution_time} secs")
+        LOG.info(f"Total execution time: {round(process_time, 2)} secs")

--- a/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
+++ b/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
@@ -28,8 +28,8 @@ if typing.TYPE_CHECKING:
 class Model:
     dt: int
 
-    def __init__(self, config_file: str):
-        self._time = 0.0
+    def __init__(self, config_file: str, start_time: float):
+        self._time = start_time
 
         with open(config_file) as reader:
             data = yaml.load(reader, Loader=yaml.SafeLoader)
@@ -247,7 +247,7 @@ class Model:
         self._timings["output_time"] = time.time() - output_start_time
 
         # update time as (ngen dt in seconds) * (number of steps processed)
-        self._time += self._ngen_dt(bmi_values) * qlats.shape[1]
+        self._time += self.ngen_dt(bmi_values) * qlats.shape[1]
 
     def log_times(self):
         if self.show_timing:
@@ -375,8 +375,8 @@ class Model:
     def qts_subdivisions(self) -> int:
         return self.forcing_parameters["qts_subdivisions"]
 
-    def _ngen_dt(self, bmi_values: dict[str, NDArray]) -> int:
-        if ("ngen_dt" in bmi_values) and (len(bmi_values["ngen_dt"]) == 1):
+    def ngen_dt(self, bmi_values: dict[str, NDArray]) -> int:
+        if len(bmi_values.get("ngen_dt", "")) == 1:
             dt = bmi_values["ngen_dt"][0]
             if dt > 0:
                 return int(dt)
@@ -384,7 +384,7 @@ class Model:
         return int(self.dt * self.qts_subdivisions)
 
     def _construct_qlats(self, bmi_values: dict[str, NDArray]):
-        dt = self._ngen_dt(bmi_values)
+        dt = self.ngen_dt(bmi_values)
         step_time = self._network.t0
         water_source_ids = bmi_values["land_surface_water_source__id"]
         water_source_values = bmi_values["land_surface_water_source__volume_flow_rate"]

--- a/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
+++ b/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
@@ -72,6 +72,7 @@ class Model:
         else:
             raise Exception("Supernetwork network type must be HYFeaturesNetwork or NHDNetwork")
         self._network.assemble_coastal_coupling_data()
+        self._orig_t0 = self._network.t0
         network_creation_time = time.time() - network_start_time
 
         # Data data assimilation
@@ -102,7 +103,6 @@ class Model:
         # to function from inital loop.     
         self._subnetwork = [None, None, None]
 
-        self._df_data = {}
         self._timings = {
             "forcing_time": forcing_time,
             "route_time": 0.0,
@@ -110,31 +110,13 @@ class Model:
             "network_creation_time": network_creation_time,
         }
 
-
-    def update(self, bmi_values: dict):
-        start = time.time()
-        qlat_values = bmi_values["land_surface_water_source__volume_flow_rate"]
-        step_time = self._network.t0 + timedelta(seconds=self.time)
-        timestamp = step_time.strftime("%Y%m%d%H%M")
-        self._df_data[timestamp] = np.array(qlat_values)
-        self._time += self.ngen_dt
-        self._timings["forcing_time"] += time.time() - start
-
-
     def run(self, bmi_values: dict[str, NDArray]):
         qts_subdivisions = self.qts_subdivisions
         nts = self.nts
 
         LOG.debug("Assembling forcing dataframe")
         forcing_start_time = time.time()
-        ## setup the qlats dataframe from the update() data
-        qlats = pd.DataFrame(data=self._df_data, index=bmi_values["land_surface_water_source__id"])
-        # Take flowpath ids entering NEXUS and replace NEXUS ids by the upstream flowpath ids
-        qlats = qlats.rename(index=self._network.downstream_flowpath_dict)
-        # create zero values for missing values
-        missing = self._network.segment_index[~self._network.segment_index.isin(qlats.index)]
-        zeros = pd.DataFrame(data=0.0, index=missing, columns=qlats.columns)
-        qlats = pd.concat([qlats, zeros]).sort_index()
+        qlats = self._construct_qlats(bmi_values)
         self._timings["forcing_time"] += time.time() - forcing_start_time
 
         if len(bmi_values["upstream_id"]) > 0:
@@ -265,6 +247,10 @@ class Model:
 
         self._timings["output_time"] = time.time() - output_start_time
 
+        # update time as (ngen dt in seconds) * (number of steps processed)
+        self._time += self.ngen_dt * qlats.shape[1]
+
+    def log_times(self):
         if self.show_timing:
             self._log_times()
 
@@ -276,6 +262,7 @@ class Model:
             if isinstance(value, dict):
                 subnetwork[i] = dict(value)
         return {
+            "time": self._time,
             "subnetwork": subnetwork,
             # updated data stored on AbstractNetwork
             "q0": self._network._q0,
@@ -289,14 +276,20 @@ class Model:
         }
 
     def load_state(self, data: dict):
+        self._time = data["time"]
         self._subnetwork = data["subnetwork"]
         self._network._q0 = data["q0"]
         self._network._t0 = data["t0"]
-        self._data_assimilation._last_obs_df = data["lat_obs"]
+        self._data_assimilation._last_obs_df = data["last_obs"]
         self._data_assimilation._reservoir_usgs_param_df = data["usgs"]
         self._data_assimilation._reservoir_usace_param_df = data["usace"]
         self._data_assimilation._reservoir_rfc_param_df = data["rfc"]
         self._data_assimilation._great_lakes_param_df = data["gl"]
+        self._network.update_waterbody_water_elevation()
+
+    def reset_time(self):
+        self._time = 0.0
+        self._network.t0 = self._orig_t0
 
     @property
     def nts(self) -> int:
@@ -386,6 +379,31 @@ class Model:
     @property
     def ngen_dt(self) -> int:
         return int(self.dt * self.qts_subdivisions)
+
+    def _construct_qlats(self, bmi_values: dict[str, NDArray]):
+        dt = self.ngen_dt
+        step_time = self._network.t0
+        water_source_ids = bmi_values["land_surface_water_source__id"]
+        water_source_values = bmi_values["land_surface_water_source__volume_flow_rate"]
+        num_ids = len(water_source_ids)
+        # build the dataframe data
+        # the flow rate data should be organized as one large array broken into chunks per timestep with sources aligned with the IDs
+        df_data = {}
+        index = 0
+        while index < len(water_source_values):
+            timeslice = water_source_values[index:(index + num_ids)]
+            timestamp = step_time.strftime("%Y%m%d%H%M")
+            df_data[timestamp] = timeslice
+            step_time += timedelta(seconds=dt)
+            index += num_ids
+        ## use a DataFrame to view the inputs grouped by timestep
+        qlats = pd.DataFrame(data=df_data, index=water_source_ids)
+        # Take flowpath ids entering NEXUS and replace NEXUS ids by the upstream flowpath ids
+        qlats = qlats.rename(index=self._network.downstream_flowpath_dict)
+        # create zero values for missing values
+        missing = self._network.segment_index[~self._network.segment_index.isin(qlats.index)]
+        zeros = pd.DataFrame(data=0.0, index=missing, columns=qlats.columns)
+        return pd.concat([qlats, zeros]).sort_index()
 
     def _log_times(self):
         def sec_and_per(title, key: str):

--- a/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
+++ b/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
@@ -232,12 +232,6 @@ class Model:
         )
 
         self._network.new_t0(self.dt, nts)
-        if self._da_index < len(self._da_sets):
-            self._data_assimilation.update_for_next_loop(
-                self._network,
-                self._da_sets[self._da_index]
-            )
-            self._da_index += 1
 
         # compute BMI outputs
         def _update_values(name: str, values: pd.Series | pd.Index):
@@ -273,6 +267,36 @@ class Model:
 
         if self.show_timing:
             self._log_times()
+
+    def create_state(self):
+        """Create a dictionary of data that can be serialized using `pickle.dumps`."""
+        # save current subnetwork and convert defaultdicts to dicts
+        subnetwork = list(self._subnetwork)
+        for i, value in enumerate(subnetwork):
+            if isinstance(value, dict):
+                subnetwork[i] = dict(value)
+        return {
+            "subnetwork": subnetwork,
+            # updated data stored on AbstractNetwork
+            "q0": self._network._q0,
+            "t0": self._network._t0,
+            # updated data stored on DataAssimilation
+            "last_obs": self._data_assimilation._last_obs_df,
+            "usgs": self._data_assimilation._reservoir_usgs_param_df,
+            "usace": self._data_assimilation._reservoir_usace_param_df,
+            "rfc": self._data_assimilation._reservoir_rfc_param_df,
+            "gl": self._data_assimilation._great_lakes_param_df,
+        }
+
+    def load_state(self, data: dict):
+        self._subnetwork = data["subnetwork"]
+        self._network._q0 = data["q0"]
+        self._network._t0 = data["t0"]
+        self._data_assimilation._last_obs_df = data["lat_obs"]
+        self._data_assimilation._reservoir_usgs_param_df = data["usgs"]
+        self._data_assimilation._reservoir_usace_param_df = data["usace"]
+        self._data_assimilation._reservoir_rfc_param_df = data["rfc"]
+        self._data_assimilation._great_lakes_param_df = data["gl"]
 
     @property
     def nts(self) -> int:

--- a/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
+++ b/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
@@ -1,6 +1,8 @@
 """Basic Model Interface backing model for NGEN t-route."""
+from __future__ import annotations
 import logging
 import time
+import typing
 import yaml
 import numpy as np
 import pandas as pd
@@ -18,6 +20,10 @@ from nwm_routing.output import nwm_output_generator
 
 from troute_ewts import configure_logging, MODULE_NAME
 LOG = logging.getLogger(MODULE_NAME)
+
+if typing.TYPE_CHECKING:
+    from numpy.typing import NDArray
+
 
 class Model:
     dt: int
@@ -111,13 +117,13 @@ class Model:
         step_time = self._network.t0 + timedelta(seconds=self.time)
         timestamp = step_time.strftime("%Y%m%d%H%M")
         self._df_data[timestamp] = np.array(qlat_values)
-        self._time += self.dt
+        self._time += self.ngen_dt
         self._timings["forcing_time"] += time.time() - start
 
 
-    def run(self, bmi_values: dict):
+    def run(self, bmi_values: dict[str, NDArray]):
+        qts_subdivisions = self.qts_subdivisions
         nts = self.nts
-        qts_subdivisions = self.forcing_parameters.get('qts_subdivisions', 12)
 
         LOG.debug("Assembling forcing dataframe")
         forcing_start_time = time.time()
@@ -135,6 +141,10 @@ class Model:
             flowveldepth_interorder = {bmi_values['upstream_id'][0]: {"results": bmi_values['upstream_fvd']}}
         else:
             flowveldepth_interorder = {}
+
+        usgs_df = self._data_assimilation.usgs_df
+        if not usgs_df.empty:
+            usgs_df = usgs_df.loc[:,self._network.t0:]
 
         LOG.debug("Starting routing function")
         route_start_time = time.time()
@@ -155,7 +165,7 @@ class Model:
             param_df=self._network.dataframe,
             q0=self._network.q0,
             qlats=qlats,
-            usgs_df=self._data_assimilation.usgs_df,
+            usgs_df=usgs_df,
             lastobs_df=self._data_assimilation.lastobs_df,
             reservoir_usgs_df=self._data_assimilation.reservoir_usgs_df,
             reservoir_usgs_param_df=self._data_assimilation.reservoir_usgs_param_df,
@@ -220,6 +230,45 @@ class Model:
             nexus_dict=self._network.nexus_dict,
             poi_crosswalk=self._network.poi_nex_dict or {},
         )
+
+        self._network.new_t0(self.dt, nts)
+        if self._da_index < len(self._da_sets):
+            self._data_assimilation.update_for_next_loop(
+                self._network,
+                self._da_sets[self._da_index]
+            )
+            self._da_index += 1
+
+        # compute BMI outputs
+        def _update_values(name: str, values: pd.Series | pd.Index):
+            dtype = bmi_values[name].dtype
+            array = bmi_values[name] = values.to_numpy().astype(dtype)
+            return array
+        qvd_columns = pd.MultiIndex.from_product(
+            [range(nts), ["q", "v", "d"]]
+        ).to_flat_index()
+        flowveldepth = pd.concat(
+            [pd.DataFrame(r[1], index=r[0], columns=qvd_columns) for r in run_results],
+            copy=False,
+        )
+        _update_values("channel_exit_water_x-section__volume_flow_rate", flowveldepth.iloc[:,-3])
+        _update_values("channel_water_flow__speed", flowveldepth.iloc[:,-2])
+        _update_values("channel_water__mean_depth", flowveldepth.iloc[:,-1])
+        _update_values("channel_water__id", flowveldepth.index)
+
+        i_columns = pd.MultiIndex.from_product(
+            [range(int(nts)), ["i"]]
+        ).to_flat_index()
+        wbdy = pd.concat(
+            [pd.DataFrame(r[6], index=r[0], columns=i_columns) for r in run_results],
+            copy=False,
+        )
+
+        wbdy_id = _update_values("lake_water__id", self._network.waterbody_dataframe.index)
+        _update_values("lake_water~incoming__volume_flow_rate", wbdy.loc[wbdy_id].iloc[:,-1])
+        _update_values("lake_water~outgoing__volume_flow_rate", flowveldepth.loc[wbdy_id].iloc[:,-3])
+        _update_values("lake_surface__elevation", flowveldepth.loc[wbdy_id].iloc[:,-1])
+
         self._timings["output_time"] = time.time() - output_start_time
 
         if self.show_timing:
@@ -305,6 +354,14 @@ class Model:
     @property
     def t0(self) -> datetime:
         return self._network.t0
+
+    @property
+    def qts_subdivisions(self) -> int:
+        return self.forcing_parameters["qts_subdivisions"]
+
+    @property
+    def ngen_dt(self) -> int:
+        return int(self.dt * self.qts_subdivisions)
 
     def _log_times(self):
         def sec_and_per(title, key: str):

--- a/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
+++ b/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
@@ -217,7 +217,7 @@ class Model:
         # compute BMI outputs
         def _update_values(name: str, values: pd.Series | pd.Index):
             dtype = bmi_values[name].dtype
-            array = bmi_values[name] = values.to_numpy().astype(dtype)
+            array = bmi_values[name] = values.to_numpy(dtype=dtype, copy=True)
             return array
         qvd_columns = pd.MultiIndex.from_product(
             [range(nts), ["q", "v", "d"]]


### PR DESCRIPTION
This PR adds messaging for creating, retrieving, and freeing serialization states for the T-Route BMI. The extent of the data saved includes data stored on the `AbstractNetwork` and `DataAssimilation` objects.

Note: Because of some structural changes to the BMI, this PR must be merged alongside the implementation of state saving in NGEN. Merging prior to the changes made there will break the communication of data between the two.

## Additions

- Messaging variables for working with state data.
- Variables on the BMI representing the output results from a T-Route run.

## Removals

-

## Changes

-

## Testing

1. Test script demonstrating the new architecture can work with data loaded from NGEN output nexus CSVs.
2. Testing on AWS Workspaces using the state saving branch of NGEN, the output results with the new architecture for sending data from NGEN to T-Route and interpreting that data.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [x] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
