### PR TITLE
Fix Stale Python OS Environment when EWTS runs with ngen. (NGWPC-9694)

### DIFF
--- a/src/troute-nwm/src/nwm_routing/input.py
+++ b/src/troute-nwm/src/nwm_routing/input.py
@@ -8,8 +8,8 @@ import troute.nhd_io as nhd_io
 import troute.nhd_network_utilities_v02 as nnu
 from troute.config import Config
 
-from troute_ewts import configure_logging
-LOG = configure_logging()
+from troute_ewts import MODULE_NAME
+LOG = logging.getLogger(MODULE_NAME)
 
 def _input_handler_v04(args):
     '''

--- a/src/troute_ewts/src/troute_ewts/config.py
+++ b/src/troute_ewts/src/troute_ewts/config.py
@@ -43,6 +43,7 @@ from .constants import (
 )
 from .formatter import CustomFormatter
 from .paths import get_log_file_path
+from .env import getenv_any
 
 def translate_ngwpc_log_level(level: str) -> str:
     level = level.strip().upper()
@@ -75,7 +76,7 @@ def configure_logging():
         return logger # logger already initialized, nothing else to do
 
     # Default to enabled if flag not set or is set to disabled
-    raw_value = os.getenv(EV_EWTS_LOGGING)
+    raw_value = getenv_any(EV_EWTS_LOGGING, "")
     normalized = (raw_value or "").strip().lower()  # convert None or "" to "", lowercase for easy comparison
 
     # Determine if logging is enabled
@@ -102,7 +103,7 @@ def configure_logging():
     )
 
     log_level = translate_ngwpc_log_level(
-        os.getenv(EV_MODULE_LOGLEVEL, "INFO")
+        getenv_any(EV_MODULE_LOGLEVEL, "INFO")
     )
 
     module_fmt = MODULE_NAME.upper().ljust(LOG_MODULE_NAME_LEN)[:LOG_MODULE_NAME_LEN]

--- a/src/troute_ewts/src/troute_ewts/env.py
+++ b/src/troute_ewts/src/troute_ewts/env.py
@@ -1,0 +1,32 @@
+import os
+
+# NOTE:
+# ngen sets some env vars from C++ after the Python interpreter has started.
+# In embedded Python, os.environ may not reflect those changes.
+# getenv_any() falls back to libc getenv() and syncs os.environ.
+def getenv_any(key: str, default: str = "") -> str:
+    """
+    Get an environment variable reliably even when it is set from C/C++
+    after the Python interpreter has started (embedded Python).
+    Prefers os.environ/os.getenv, falls back to libc getenv.
+    """
+    # First try Python's mapping
+    v = os.environ.get(key)
+    if v is not None:
+        return v
+
+    # Fallback: direct libc getenv (sees process env even if Python mapping is stale)
+    try:
+        import ctypes, ctypes.util
+        libc = ctypes.CDLL(ctypes.util.find_library("c"))
+        libc.getenv.restype = ctypes.c_char_p
+        b = libc.getenv(key.encode("utf-8"))
+        if not b:
+            return default
+        s = b.decode("utf-8")
+
+        # Sync back into os.environ so future lookups work normally
+        os.environ[key] = s
+        return s
+    except Exception:
+        return default

--- a/src/troute_ewts/src/troute_ewts/paths.py
+++ b/src/troute_ewts/src/troute_ewts/paths.py
@@ -30,6 +30,7 @@ import getpass
 import os
 from datetime import datetime, timezone
 
+from .env import getenv_any
 from .constants import (
     MODULE_NAME,
     EV_NGEN_LOGFILEPATH,
@@ -66,13 +67,13 @@ def get_log_file_path():
     appendEntries = True
     moduleLogFileExists = False
 
-     # Determine if a log file has laready been opened for this module (either the ngen log or default)
-    moduleEnvVar = os.getenv(EV_MODULE_LOGFILEPATH, "")
+     # Determine if a log file has already been opened for this module (either the ngen log or default)
+    moduleEnvVar = (os.getenv(EV_MODULE_LOGFILEPATH) or "").strip()
     if moduleEnvVar:
         logFilePath = moduleEnvVar
         moduleLogFileExists = True
     else:
-        ngenEnvVar = os.getenv(EV_NGEN_LOGFILEPATH, "")
+        ngenEnvVar = getenv_any(EV_NGEN_LOGFILEPATH).strip()
         if ngenEnvVar:
             logFilePath = ngenEnvVar
         else:


### PR DESCRIPTION
ngen ( C++ ) is calling setenv() after Python has already initialized os.environ, and Python’s os.environ mapping is not automatically refreshed when the environment is mutated from C/C++.

So Python keeps an internal view of the environment that includes things set before Python started (like NGEN_RESULTS_DIR), but not variables injected later from C++ (like NGEN_LOG_FILE_PATH).

Added a helper method to ensure the Python os environment is not stale when T-Route runs.

## Additions

- env.py file
- getenv_any() helper method to read the environment variables from the calling program os environment, updating the python os environment in the process.


## Changes

- Call to configure_logging change to get_logger
- Calls to os.getenv changes to getenv_any

## Testing

1. Ran several tests runs changing the debug level and seeing the expected results in the ngen.log file

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
