### PR TITLE
Update compiler.sh to install ewts package from GitHub

### DIFF
--- a/compiler.sh
+++ b/compiler.sh
@@ -6,16 +6,20 @@
 #set root folder of github repo (should be named t-route)
 REPOROOT=`pwd`
 
-# Path to nwm-ewts python package source (development fallback)
-: "${EWTS_PY_ROOT:=$REPOROOT/../../../nwm-ewts/runtime/python/ewts}"
+########################################################################
+# Change/Verify these values when adopting this script into another org:
+#   GH_ORG, EWTS_GIT_REF
+########################################################################
+# EWTS GitHub source
+: "${GH_ORG:=NGWPC}"
+: "${EWTS_GIT_REF:=development}"
+: "${EWTS_GIT_URL:=https://github.com/${GH_ORG}/nwm-ewts.git}"
+: "${EWTS_PY_SUBDIR:=runtime/python/ewts}"
 
-# Preferred EWTS install prefix and wheel location
-: "${EWTS_PREFIX:=/tmp/ewts_install}"
-: "${EWTS_WHEEL_DIR:=$EWTS_PREFIX/python/dist}"
-
-echo "using EWTS_PY_ROOT=${EWTS_PY_ROOT}"
-echo "using EWTS_PREFIX=${EWTS_PREFIX}"
-echo "using EWTS_WHEEL_DIR=${EWTS_WHEEL_DIR}"
+echo "Installing EWTS from GitHub:"
+echo "  repo: ${EWTS_GIT_URL}"
+echo "  ref:  ${EWTS_GIT_REF}"
+echo "  dir:  ${EWTS_PY_SUBDIR}"
 
 #For each build step, you can set these to true to make it build
 #or set it to anything else (or unset) to skip that step
@@ -128,27 +132,12 @@ if [[ "$build_reservoir_kernel" == true ]]; then
 fi
 
 # Remove any old/stale ewts/troute_ewts from the environment to avoid shadowing
-pip uninstall -y ewts troute_ewts >/dev/null 2>&1 || true
+$PIP_CMD uninstall -y ewts troute_ewts >/dev/null 2>&1 || true
 
-# Prefer installed EWTS wheel; fall back to source tree for development
-EWTS_WHEEL=""
-if compgen -G "${EWTS_WHEEL_DIR}/ewts-*.whl" > /dev/null; then
-  EWTS_WHEEL=$(ls -1t "${EWTS_WHEEL_DIR}"/ewts-*.whl | head -n 1)
-fi
-
-if [[ -n "${EWTS_WHEEL}" ]]; then
-  echo "Installing EWTS from wheel: ${EWTS_WHEEL}"
-  pip install "${EWTS_WHEEL}" || exit
-else
-  echo "No EWTS wheel found in ${EWTS_WHEEL_DIR}"
-  echo "Falling back to source install from ${EWTS_PY_ROOT}"
-
-  if [[ ${WITH_EDITABLE} == true ]]; then
-    pip install --editable "${EWTS_PY_ROOT}" || exit
-  else
-    pip install "${EWTS_PY_ROOT}" || exit
-  fi
-fi
+# Install EWTS directly from GitHub
+$PIP_CMD install \
+    "ewts @ git+${EWTS_GIT_URL}@${EWTS_GIT_REF}#subdirectory=${EWTS_PY_SUBDIR}" \
+    || exit
 
 if [[ "$build_framework" == true ]]; then
   cd $REPOROOT/src/troute-network


### PR DESCRIPTION
Update compiler.sh to install ewts package from GitHub instead of requiring the developer to clone the repository to their local work environment before installing it.

## Additions

- Added script variables to compiler.sh 
  - `GH_ORG`: GitHub Organization (GH_ORG). Currently `NGWPC`
  - `EWTS_GIT_URL`: EWTS GitHub URL. 
  - `EWTS_REF`: branch to use. Currently `development`.
  - `EWTS_PY_SUBDIR`: Subdirectory containing the ewts python package

## Removals

- No longer install the Python package from a local directory in compiler.sh

## To Do's

- When an NGWPC official release is made:
  -  Update `EWTS_REF`  to point to the appropriate release branch.
- When merged to OWP parent repository:
  - Update `GH_ORG` to the reflect to correct name of the OWP GitHub account.
  - Update `EWTS_REF`:  to the `master` branch

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: