### PR TITLE
Use new EWTS configure_existing_logger

### DIFF
--- a/compiler_bmi.sh
+++ b/compiler_bmi.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
+set -e
 
-#TODO add options for clean/noclean, make/nomake, cython/nocython
-#TODO include instuctions on blowing away entire package for fresh install e.g. rm -r ~/venvs/mesh/lib/python3.6/site-packages/troute/*
-
-#set root folder of github repo (should be named t-route)
-REPOROOT=`pwd`
+# This script install EWTS for running t-route in ngen then  
+# calls the compiler.sh to install remaining dependencies
 
 ########################################################################
 # Change/Verify these values when adopting this script into another org:
@@ -21,43 +19,14 @@ echo "  repo: ${EWTS_GIT_URL}"
 echo "  ref:  ${EWTS_GIT_REF}"
 echo "  dir:  ${EWTS_PY_SUBDIR}"
 
-#For each build step, you can set these to true to make it build
-#or set it to anything else (or unset) to skip that step
-build_mc_kernel=true
-build_diffusive_tulane_kernel=true
-build_reservoir_kernel=true
-build_framework=true
-build_routing=true
-build_config=true
-build_nwm=true
-build_bmi=true
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-if [ -z "$F90" ]
-then
-    export F90="gfortran"
-    echo "using F90=${F90}"
-fi
-
-if [ -z "$CC" ]
-then
-    export CC="gcc"
-    echo "using CC=${CC}"
-fi
-
-# Parse command line arguments
-WITH_EDITABLE=true
-USE_UV=false
+# Parse only BMI/EWTS-specific args here.
+# Pass all standard compiler.sh args through unchanged.
+PASSTHROUGH_ARGS=()
 
 while [[ $# -gt 0 ]]; do
-    case $1 in
-        no-e)
-            WITH_EDITABLE=false
-            shift
-            ;;
-        --uv)
-            USE_UV=true
-            shift
-            ;;
+    case "$1" in
         --gh-org)
             GH_ORG="$2"
             if [[ -z "$2" ]]; then
@@ -76,132 +45,34 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         *)
-            echo "Unknown option: $1"
-            echo "Usage: $0 [no-e] [--uv]"
-            echo "  no-e: Install packages without editable mode"
-            echo "  --uv: Use uv pip instead of pip"
-            exit 1
+            PASSTHROUGH_ARGS+=("$1")
+            shift
             ;;
     esac
 done
 
-# set pip command based on UV flag
+# Use uv pip if --uv is present in the arguments
+USE_UV=false
+for arg in "${PASSTHROUGH_ARGS[@]}"; do
+    if [[ "$arg" == "--uv" ]]; then
+        USE_UV=true
+        break
+    fi
+done
+
 if [[ "$USE_UV" == true ]]; then
     PIP_CMD="uv pip"
-    echo "Using uv pip for package installation"
+    echo "Using uv pip for EWTS installation"
 else
     PIP_CMD="pip"
-    echo "Using standard pip for package installation"
-fi
-
-#if you have custom static library paths, uncomment below and export them
-#export LIBRARY_PATH=<paths>:$LIBRARY_PATH
-#if you have custom dynamic library paths, uncomment below and export them
-#export LD_LIBRARY_PATHS=<paths>:$LD_LIBRARY_PATHS
-
-if [ -z "$NETCDF" ]
-then
-    export NETCDFINC=/usr/include/openmpi-x86_64/
-    # set alternative NETCDF variable include path, for example for WSL
-    # (Windows Subsystems for Linux).
-    #
-    # EXAMPLE USAGE: export NETCDFALTERNATIVE=$HOME/.conda/envs/py39/include/
-    # (before ./compiler.sh)
-    if [ -n "$NETCDFALTERNATIVE" ]
-    then
-        echo "using alternative NETCDF inc ${NETCDFALTERNATIVE}"
-        export NETCDFINC=$NETCDFALTERNATIVE
-    fi
-else
-    export NETCDFINC="${NETCDF}"
-fi
-echo "using NETCDFINC=${NETCDFINC}"
-
-
-if  [[ "$build_mc_kernel" == true ]]; then
-  #building reach and resevoir kernel files .o
-  cd $REPOROOT/src/kernel/muskingum/
-  make clean
-  make  || exit
-  make install || exit
-fi
-
-if  [[ "$build_diffusive_tulane_kernel" == true ]]; then
-  #building reach and resevoir kernel files .o
-  cd $REPOROOT/src/kernel/diffusive/
-  make clean
-  make diffusive.o
-  make pydiffusive.o
-  make chxsec_lookuptable.o
-  make pychxsec_lookuptable.o
-  make install || exit
-fi
-
-if [[ "$build_reservoir_kernel" == true ]]; then
-    cd $REPOROOT/src/kernel/reservoir/
-    make clean
-    #make NETCDFINC=`nc-config --includedir` || exit
-    #make binding_lp.a
-    #make install_lp || exit
-    make
-    make install_lp || exit
-    make install_rfc || exit
+    echo "Using standard pip for EWTS installation"
 fi
 
 # Remove any old/stale ewts/troute_ewts from the environment to avoid shadowing
 $PIP_CMD uninstall -y ewts troute_ewts >/dev/null 2>&1 || true
 
-# Install EWTS directly from GitHub
 $PIP_CMD install \
-    "ewts @ git+${EWTS_GIT_URL}@${EWTS_GIT_REF}#subdirectory=${EWTS_PY_SUBDIR}" \
-    || exit
+    "ewts @ git+${EWTS_GIT_URL}@${EWTS_GIT_REF}#subdirectory=${EWTS_PY_SUBDIR}"
 
-if [[ "$build_framework" == true ]]; then
-  cd $REPOROOT/src/troute-network
-  if [[ ${WITH_EDITABLE} == true ]]; then
-    pip install --no-build-isolation --config-setting='--build-option=--use-cython' --editable . --config-setting='editable_mode=compat' || exit
-  else
-    pip install --no-build-isolation --config-setting='--build-option=--use-cython' . || exit
-  fi
-fi
-
-if [[ "$build_routing" == true ]]; then
-    #updates troute package with the execution script
-    cd $REPOROOT/src/troute-routing
-    rm -rf build
-    
-    if [[ ${WITH_EDITABLE} == true ]]; then
-        $PIP_CMD install --no-build-isolation --config-setting='--build-option=--use-cython' --editable . --config-setting='editable_mode=compat' || exit
-    else
-        $PIP_CMD install --no-build-isolation --config-setting='--build-option=--use-cython' . || exit
-    fi
-fi
-
-if [[ "$build_config" == true ]]; then
-    #updates troute package with the execution script
-    cd $REPOROOT/src/troute-config
-    if [[ ${WITH_EDITABLE} == true ]]; then
-        $PIP_CMD install --editable . || exit
-    else
-        $PIP_CMD install . || exit
-    fi
-fi
-
-if [[ "$build_nwm" == true ]]; then
-    #updates troute package with the execution script
-    cd $REPOROOT/src/troute-nwm
-    if [[ ${WITH_EDITABLE} == true ]]; then
-        $PIP_CMD install --editable . || exit
-    else
-        $PIP_CMD install . || exit
-    fi
-fi
-
-if [[ "$build_bmi" == true ]]; then
-  cd $REPOROOT/src/troute-bmi
-  if [[ ${WITH_EDITABLE} == true ]]; then
-    pip install --editable . || exit
-  else
-    pip install . || exit
-  fi
-fi
+# Now run the original standalone compiler script for everything else
+exec "${SCRIPT_DIR}/compiler.sh" "${PASSTHROUGH_ARGS[@]}"

--- a/compiler_bmi.sh
+++ b/compiler_bmi.sh
@@ -6,6 +6,21 @@
 #set root folder of github repo (should be named t-route)
 REPOROOT=`pwd`
 
+########################################################################
+# Change/Verify these values when adopting this script into another org:
+#   GH_ORG, EWTS_GIT_REF
+########################################################################
+# EWTS GitHub source
+: "${GH_ORG:=NGWPC}"
+: "${EWTS_GIT_REF:=development}"
+: "${EWTS_GIT_URL:=https://github.com/${GH_ORG}/nwm-ewts.git}"
+: "${EWTS_PY_SUBDIR:=runtime/python/ewts}"
+
+echo "Installing EWTS from GitHub:"
+echo "  repo: ${EWTS_GIT_URL}"
+echo "  ref:  ${EWTS_GIT_REF}"
+echo "  dir:  ${EWTS_PY_SUBDIR}"
+
 #For each build step, you can set these to true to make it build
 #or set it to anything else (or unset) to skip that step
 build_mc_kernel=true
@@ -42,6 +57,23 @@ while [[ $# -gt 0 ]]; do
         --uv)
             USE_UV=true
             shift
+            ;;
+        --gh-org)
+            GH_ORG="$2"
+            if [[ -z "$2" ]]; then
+                echo "Error: --gh-org requires a value"
+                exit 1
+            fi
+            EWTS_GIT_URL="https://github.com/${GH_ORG}/nwm-ewts.git"
+            shift 2
+            ;;
+        --ewts-ref)
+            EWTS_GIT_REF="$2"
+            if [[ -z "$2" ]]; then
+                echo "Error: --ewts-ref requires a value"
+                exit 1
+            fi
+            shift 2
             ;;
         *)
             echo "Unknown option: $1"
@@ -115,6 +147,14 @@ if [[ "$build_reservoir_kernel" == true ]]; then
     make install_lp || exit
     make install_rfc || exit
 fi
+
+# Remove any old/stale ewts/troute_ewts from the environment to avoid shadowing
+$PIP_CMD uninstall -y ewts troute_ewts >/dev/null 2>&1 || true
+
+# Install EWTS directly from GitHub
+$PIP_CMD install \
+    "ewts @ git+${EWTS_GIT_URL}@${EWTS_GIT_REF}#subdirectory=${EWTS_PY_SUBDIR}" \
+    || exit
 
 if [[ "$build_framework" == true ]]; then
   cd $REPOROOT/src/troute-network

--- a/src/model_DAforcing.py
+++ b/src/model_DAforcing.py
@@ -19,7 +19,6 @@ from troute.routing.fast_reach.reservoir_RFC_da import _validate_RFC_data
 import netCDF4
 from troute.config import Config
 
-import logging
 LOG = logging.getLogger("TROUTE")
 
 class DAforcing_model():

--- a/src/model_DAforcing.py
+++ b/src/model_DAforcing.py
@@ -19,8 +19,8 @@ from troute.routing.fast_reach.reservoir_RFC_da import _validate_RFC_data
 import netCDF4
 from troute.config import Config
 
-import ewts
-LOG = ewts.get_logger(ewts.T_ROUTE_ID)
+import logging
+LOG = logging.getLogger("TROUTE")
 
 class DAforcing_model():
 

--- a/src/troute-bmi/src/troute_nwm_bmi/troute_bmi.py
+++ b/src/troute-bmi/src/troute_nwm_bmi/troute_bmi.py
@@ -4,14 +4,17 @@ import pickle
 import typing
 import numpy as np
 from bmipy import Bmi
+import logging
+
+from ewts.helper import getenv_any
+from ewts.logger import configure_existing_logger
 
 from .troute_model import Model, BmiVars
 
 if typing.TYPE_CHECKING:
     from numpy.typing import NDArray
 
-import ewts
-LOG = ewts.get_logger(ewts.T_ROUTE_ID)
+LOG = logging.getLogger("TROUTE")
 
 _VAR_NAME_UNITS_MAP = {
     BmiVars.CATCHMENT_VALUE: ['streamflow_cms', 'm3 s-1'],
@@ -49,9 +52,10 @@ class BmiTroute(Bmi):
     _model: Model
 
     def __init__(self):
-        # This is required prior to the first log message is issued by t-route.
-        LOG.bind()
-        
+        val = getenv_any("EWTS_USE_NGEN_BRIDGE", "").strip().lower()
+        if val in {"1", "true", "yes", "on"}:
+            configure_existing_logger(LOG)
+
         super().__init__()
         self._values: dict[str, NDArray] = {
             BmiVars.NGEN_DT: np.array([-1], dtype=np.intc),

--- a/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
+++ b/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
@@ -21,8 +21,8 @@ import troute.hyfeature_network_utilities as hnu
 import nwm_routing.nwm_route as nwm_routing
 from nwm_routing.output import nwm_output_generator, remap_outputs
 
-import ewts
-LOG = ewts.get_logger(ewts.T_ROUTE_ID)
+import logging
+LOG = logging.getLogger("TROUTE")
 
 if typing.TYPE_CHECKING:
     from numpy.typing import NDArray

--- a/src/troute-network/troute/AbstractNetwork.py
+++ b/src/troute-network/troute/AbstractNetwork.py
@@ -17,8 +17,8 @@ from troute.nhd_network_utilities_v02 import organize_independent_networks
 import troute.nhd_io as nhd_io 
 from .AbstractRouting import MCOnly, MCwithDiffusive, MCwithDiffusiveNatlXSectionNonRefactored, MCwithDiffusiveNatlXSectionRefactored
 
-import ewts
-LOG = ewts.get_logger(ewts.T_ROUTE_ID)
+import logging
+LOG = logging.getLogger("TROUTE")
 
 class AbstractNetwork(ABC):
     """

--- a/src/troute-network/troute/AbstractRouting.py
+++ b/src/troute-network/troute/AbstractRouting.py
@@ -9,8 +9,8 @@ from itertools import chain
 from troute.nhd_network import reverse_network, reachable
 from troute.nhd_network_utilities_v02 import organize_independent_networks, build_refac_connections
 
-import ewts
-LOG = ewts.get_logger(ewts.T_ROUTE_ID)
+import logging
+LOG = logging.getLogger("TROUTE")
 
 def read_diffusive_domain(domain_file):
     '''

--- a/src/troute-network/troute/AbstractRouting.py
+++ b/src/troute-network/troute/AbstractRouting.py
@@ -9,7 +9,6 @@ from itertools import chain
 from troute.nhd_network import reverse_network, reachable
 from troute.nhd_network_utilities_v02 import organize_independent_networks, build_refac_connections
 
-import logging
 LOG = logging.getLogger("TROUTE")
 
 def read_diffusive_domain(domain_file):

--- a/src/troute-network/troute/DataAssimilation.py
+++ b/src/troute-network/troute/DataAssimilation.py
@@ -11,8 +11,8 @@ import re
 import time
 import logging
 
-import ewts
-LOG = ewts.get_logger(ewts.T_ROUTE_ID)
+import logging
+LOG = logging.getLogger("TROUTE")
 
 from troute.routing.fast_reach.reservoir_RFC_da import _validate_RFC_data
 

--- a/src/troute-network/troute/DataAssimilation.py
+++ b/src/troute-network/troute/DataAssimilation.py
@@ -11,7 +11,6 @@ import re
 import time
 import logging
 
-import logging
 LOG = logging.getLogger("TROUTE")
 
 from troute.routing.fast_reach.reservoir_RFC_da import _validate_RFC_data

--- a/src/troute-network/troute/NHDNetwork.py
+++ b/src/troute-network/troute/NHDNetwork.py
@@ -12,7 +12,6 @@ import pyarrow.parquet as pq
 from troute.nhd_network import reverse_dict, extract_waterbody_connections, gage_mapping, extract_connections, replace_waterbodies_connections
 
 import logging
-import logging
 LOG = logging.getLogger("TROUTE")
 
 __showtiming__ = True #FIXME pass flag

--- a/src/troute-network/troute/NHDNetwork.py
+++ b/src/troute-network/troute/NHDNetwork.py
@@ -12,8 +12,8 @@ import pyarrow.parquet as pq
 from troute.nhd_network import reverse_dict, extract_waterbody_connections, gage_mapping, extract_connections, replace_waterbodies_connections
 
 import logging
-import ewts
-LOG = ewts.get_logger(ewts.T_ROUTE_ID)
+import logging
+LOG = logging.getLogger("TROUTE")
 
 __showtiming__ = True #FIXME pass flag
 __verbose__ = True #FIXME pass verbosity

--- a/src/troute-network/troute/NHF.py
+++ b/src/troute-network/troute/NHF.py
@@ -17,8 +17,8 @@ from troute.nhf_preprocess import (
     read_qlat_file,
 )
 
-import ewts
-LOG = ewts.get_logger(ewts.T_ROUTE_ID)
+import logging
+LOG = logging.getLogger("TROUTE")
 
 
 __verbose__ = False

--- a/src/troute-network/troute/hyfeature_network_utilities.py
+++ b/src/troute-network/troute/hyfeature_network_utilities.py
@@ -14,8 +14,8 @@ import pyarrow.parquet as pq
 
 import troute.nhd_io as nhd_io
 
-import ewts
-LOG = ewts.get_logger(ewts.T_ROUTE_ID)
+import logging
+LOG = logging.getLogger("TROUTE")
 
 def build_da_sets(da_params, run_sets, t0):
     """

--- a/src/troute-network/troute/hyfeature_network_utilities.py
+++ b/src/troute-network/troute/hyfeature_network_utilities.py
@@ -14,7 +14,6 @@ import pyarrow.parquet as pq
 
 import troute.nhd_io as nhd_io
 
-import logging
 LOG = logging.getLogger("TROUTE")
 
 def build_da_sets(da_params, run_sets, t0):

--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -20,7 +20,6 @@ from datetime import datetime, timedelta
 
 from troute.nhd_network import reverse_dict
 
-import logging
 LOG = logging.getLogger("TROUTE")
 
 def read_netcdf(geo_file_path):

--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -20,8 +20,8 @@ from datetime import datetime, timedelta
 
 from troute.nhd_network import reverse_dict
 
-import ewts
-LOG = ewts.get_logger(ewts.T_ROUTE_ID)
+import logging
+LOG = logging.getLogger("TROUTE")
 
 def read_netcdf(geo_file_path):
     '''

--- a/src/troute-network/troute/nhd_network_utilities_v02.py
+++ b/src/troute-network/troute/nhd_network_utilities_v02.py
@@ -12,8 +12,8 @@ from joblib import delayed, Parallel
 import troute.nhd_io as nhd_io
 import troute.nhd_network as nhd_network
 
-import ewts
-LOG = ewts.get_logger(ewts.T_ROUTE_ID)
+import logging
+LOG = logging.getLogger("TROUTE")
 
 def build_connections(supernetwork_parameters):
     '''

--- a/src/troute-network/troute/nhd_network_utilities_v02.py
+++ b/src/troute-network/troute/nhd_network_utilities_v02.py
@@ -12,7 +12,6 @@ from joblib import delayed, Parallel
 import troute.nhd_io as nhd_io
 import troute.nhd_network as nhd_network
 
-import logging
 LOG = logging.getLogger("TROUTE")
 
 def build_connections(supernetwork_parameters):

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -31,7 +31,6 @@ import troute.nhd_network_utilities_v02 as nnu
 import troute.hyfeature_network_utilities as hnu
 import sys
 
-import logging
 LOG = logging.getLogger("TROUTE")
 
 '''

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -31,8 +31,8 @@ import troute.nhd_network_utilities_v02 as nnu
 import troute.hyfeature_network_utilities as hnu
 import sys
 
-import ewts
-LOG = ewts.get_logger(ewts.T_ROUTE_ID)
+import logging
+LOG = logging.getLogger("TROUTE")
 
 '''
 High level orchestration of ngen t-route simulations for NWM application

--- a/src/troute-nwm/src/nwm_routing/input.py
+++ b/src/troute-nwm/src/nwm_routing/input.py
@@ -7,9 +7,10 @@ import yaml
 import troute.nhd_io as nhd_io
 import troute.nhd_network_utilities_v02 as nnu
 from troute.config import Config
+from nwm_routing.log_level_set import log_level_set
 
-import ewts
-LOG = ewts.get_logger(ewts.T_ROUTE_ID)
+import logging
+LOG = logging.getLogger("TROUTE")
 
 def _input_handler_v04(args):
     '''
@@ -35,6 +36,7 @@ def _input_handler_v04(args):
     data_assimilation_parameters (dict): Input parameters re data assimilation
 
     '''
+    
     # get name of user configuration file (e.g. test.yaml)
     custom_input_file = args.custom_input_file
 
@@ -58,6 +60,9 @@ def _input_handler_v04(args):
     hybrid_parameters = compute_parameters.get('hybrid_parameters')
     parity_parameters = output_parameters.get('wrf_hydro_parity_check')
     data_assimilation_parameters = compute_parameters.get('data_assimilation_parameters')
+    
+    # configure python logger
+    log_level_set(log_parameters)
     
     return (
         log_parameters,

--- a/src/troute-nwm/src/nwm_routing/input.py
+++ b/src/troute-nwm/src/nwm_routing/input.py
@@ -9,7 +9,6 @@ import troute.nhd_network_utilities_v02 as nnu
 from troute.config import Config
 from nwm_routing.log_level_set import log_level_set
 
-import logging
 LOG = logging.getLogger("TROUTE")
 
 def _input_handler_v04(args):

--- a/src/troute-nwm/src/nwm_routing/log_level_set.py
+++ b/src/troute-nwm/src/nwm_routing/log_level_set.py
@@ -1,0 +1,45 @@
+import logging
+import sys   
+from datetime import datetime
+import os
+
+def log_level_set(input_parameters):
+    '''
+    Set logging level and specify logger configuration.
+    
+    Arguments
+    ---------
+    input_parameters (dict): User input logging parameters
+    
+    Returns
+    -------
+    None
+    
+    Notes
+    -----
+    In the absense of user-specified logging level, level defaults to DEGUG
+    See also https://docs.python.org/3/library/logging.html
+    
+    '''
+    log_level = input_parameters.get("log_level", 'DEBUG')
+    if input_parameters.get('log_directory'):
+        directory = input_parameters.get('log_directory')
+        if not os.path.exists(directory):
+            os.makedirs(directory)
+
+        timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+        log_file_name = f"LOG_{timestamp}.log"
+        
+        logging.basicConfig(
+            level=log_level,
+            format='%(asctime)s - %(name)s - %(levelname)s - [%(filename)s:%(lineno)s - %(funcName)s]: %(message)s',
+            handlers=[
+            logging.FileHandler(os.path.join(directory, log_file_name), mode='w'),  # Log to a file
+            logging.StreamHandler(sys.stdout)  
+        ])
+    else:       
+        logging.basicConfig(
+            level=log_level,
+            format='%(asctime)s - %(name)s - %(levelname)s - [%(filename)s:%(lineno)s - %(funcName)s]: %(message)s',
+            stream=sys.stderr,
+        )   

--- a/src/troute-nwm/src/nwm_routing/nhf_routing.py
+++ b/src/troute-nwm/src/nwm_routing/nhf_routing.py
@@ -15,8 +15,8 @@ from troute.DataAssimilation import DataAssimilation
 import troute.nhd_network_utilities_v02 as nnu
 import troute.hyfeature_network_utilities as hnu
 
-import ewts
-LOG = ewts.get_logger(ewts.T_ROUTE_ID)
+import logging
+LOG = logging.getLogger("TROUTE")
 
 def nhf_routing(argv):
 

--- a/src/troute-nwm/src/nwm_routing/nwm_route.py
+++ b/src/troute-nwm/src/nwm_routing/nwm_route.py
@@ -4,8 +4,8 @@ from typing import Literal
 
 from troute.routing.compute import compute_nhd_routing_v02, compute_diffusive_routing, compute_log_mc, compute_log_diff
 
-import ewts
-LOG = ewts.get_logger(ewts.T_ROUTE_ID)
+import logging
+LOG = logging.getLogger("TROUTE")
 
 def nwm_route(
     downstream_connections,

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -7,8 +7,8 @@ import troute.nhd_io as nhd_io
 from build_tests import parity_check
 
 import logging
-import ewts
-LOG = ewts.get_logger(ewts.T_ROUTE_ID)
+import logging
+LOG = logging.getLogger("TROUTE")
 
 def _reindex_lake_to_link_id(target_df, crosswalk):
     '''

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -7,7 +7,6 @@ import troute.nhd_io as nhd_io
 from build_tests import parity_check
 
 import logging
-import logging
 LOG = logging.getLogger("TROUTE")
 
 def _reindex_lake_to_link_id(target_df, crosswalk):

--- a/src/troute-nwm/src/nwm_routing/preprocess.py
+++ b/src/troute-nwm/src/nwm_routing/preprocess.py
@@ -12,8 +12,8 @@ import troute.nhd_network_utilities_v02 as nnu
 import troute.nhd_network as nhd_network
 import troute.nhd_io as nhd_io
 
-import ewts
-LOG = ewts.get_logger(ewts.T_ROUTE_ID)
+import logging
+LOG = logging.getLogger("TROUTE")
 
 def _reindex_link_to_lake_id(target_df, crosswalk):
     '''

--- a/src/troute-nwm/src/nwm_routing/preprocess.py
+++ b/src/troute-nwm/src/nwm_routing/preprocess.py
@@ -12,7 +12,6 @@ import troute.nhd_network_utilities_v02 as nnu
 import troute.nhd_network as nhd_network
 import troute.nhd_io as nhd_io
 
-import logging
 LOG = logging.getLogger("TROUTE")
 
 def _reindex_link_to_lake_id(target_df, crosswalk):

--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -17,8 +17,8 @@ import troute.routing.diffusive_utils_v02 as diff_utils
 from troute.routing.fast_reach import diffusive
 
 import logging
-import ewts
-LOG = ewts.get_logger(ewts.T_ROUTE_ID)
+import logging
+LOG = logging.getLogger("TROUTE")
 
 if TYPE_CHECKING:
     from typing import Annotated

--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -17,7 +17,6 @@ import troute.routing.diffusive_utils_v02 as diff_utils
 from troute.routing.fast_reach import diffusive
 
 import logging
-import logging
 LOG = logging.getLogger("TROUTE")
 
 if TYPE_CHECKING:

--- a/src/troute-routing/troute/routing/fast_reach/reservoir_GL_da.py
+++ b/src/troute-routing/troute/routing/fast_reach/reservoir_GL_da.py
@@ -1,8 +1,8 @@
 import numpy as np
 from datetime import datetime, timedelta
 import logging
-import ewts
-LOG = ewts.get_logger(ewts.T_ROUTE_ID)
+import logging
+LOG = logging.getLogger("TROUTE")
 
 def great_lakes_da(
     gage_obs,

--- a/src/troute-routing/troute/routing/fast_reach/reservoir_GL_da.py
+++ b/src/troute-routing/troute/routing/fast_reach/reservoir_GL_da.py
@@ -1,7 +1,6 @@
 import numpy as np
 from datetime import datetime, timedelta
 import logging
-import logging
 LOG = logging.getLogger("TROUTE")
 
 def great_lakes_da(

--- a/src/troute-routing/troute/routing/fast_reach/reservoir_hybrid_da.py
+++ b/src/troute-routing/troute/routing/fast_reach/reservoir_hybrid_da.py
@@ -1,6 +1,5 @@
 import numpy as np
 import logging
-import logging
 LOG = logging.getLogger("TROUTE")
 
 def _modify_for_projected_storage(

--- a/src/troute-routing/troute/routing/fast_reach/reservoir_hybrid_da.py
+++ b/src/troute-routing/troute/routing/fast_reach/reservoir_hybrid_da.py
@@ -1,7 +1,7 @@
 import numpy as np
 import logging
-import ewts
-LOG = ewts.get_logger(ewts.T_ROUTE_ID)
+import logging
+LOG = logging.getLogger("TROUTE")
 
 def _modify_for_projected_storage(
     inflow, 

--- a/src/troute_model.py
+++ b/src/troute_model.py
@@ -8,8 +8,9 @@ import nwm_routing.nwm_route as tr
 
 from troute.network import bmi_array2df as a2df
 
-import ewts
-LOG = ewts.get_logger(ewts.T_ROUTE_ID)
+import logging
+LOGGER_NAME = "TROUTE"
+LOG = logging.getLogger(LOGGER_NAME)
 
 class troute_model():
 


### PR DESCRIPTION
To facilitate T-Route running standalone outside of ngen without the need to pip install the EWTS package, a new EWTS python method `configure_existing_logger` was created to reconfigure the passed existing python logger as an EWTS logger. 

## Additions

- Created new `compiler_bmi.sh` script ngen will use when t-route is run as part of ngen.
- Added call to `configure_existing_logger` in `src/troute-bmi/src/troute_nwm_bmi/troute_bmi.py` `__init__` that configures the `TROUTE` logger an EWTS logger during BMI initialization.
- Added `log_level_set.py` back to repository
- Add call to `log_level_set` in `src/troute-nwm/src/nwm_routing/input.py`  `_input_handler_v04`  

## Removals

- Removed the EWTS pip install from `compiler.sh`
- Removed all references to importing EWTS outside of `troute_bmi.sh`

## Changes

- Changed all `LOG = ewts.get_logger(ewts.T_ROUTE_ID)` to `LOG = logging.getLogger("TROUTE")` 

## Testing

1. Tested running calibrations, validations in AWS Workspace

## Todos

- Suggest adding a `constants.py` containing `LOGGER_NAME` and use this instead of hardcoding "TROUTE". 

## Notes

- Here is a link to the EWTS new [configure_existing_logger](https://github.com/NGWPC/nwm-ewts/blob/9c210c2f1c7f2cb3901d5f9a6a2bbb9dc332e2a6/runtime/python/ewts/src/ewts/logger.py#L503)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

