### PR TITLE
fix(routing): eloss_sub & qlat/qdpp init fixes; faster reach-type build

### DIFF
--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -45,9 +45,16 @@ def _format_qlat_start_time(qlat_start_time):
 
 def _build_reach_type_list(reach_list, wbodies_segs):
 
+    # No waterbody break segments (e.g. NHF stubs waterbodies): every reach is
+    # type 0 — skip the per-reach set work entirely.
+    if not wbodies_segs:
+        return [(reaches, 0) for reaches in reach_list]
+
+    # set.isdisjoint() short-circuits at the first shared element and builds no
+    # intermediate set, unlike `set(reaches) & wbodies_segs`.
     reach_type_list = [
-                1 if (set(reaches) & wbodies_segs) else 0 for reaches in reach_list
-            ]
+        0 if wbodies_segs.isdisjoint(reaches) else 1 for reaches in reach_list
+    ]
 
     return list(zip(reach_list, reach_type_list))
 

--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -805,7 +805,7 @@ def compute_nhd_routing_v02(
 
                     qlat_sub = qlats.loc[param_df_sub.index]
                     q0_sub = q0.loc[param_df_sub.index]
-                    eloss_sub = eloss_df.loc[param_df_sub.index]
+                    eloss_sub = eloss_df.reindex(param_df_sub.index).fillna(0.0)
                                         
                     param_df_sub = param_df_sub.reindex(
                         param_df_sub.index.tolist() + lake_segs
@@ -1158,7 +1158,8 @@ def compute_nhd_routing_v02(
 
                     qlat_sub = qlat_sub.reindex(param_df_sub.index)
                     q0_sub = q0_sub.reindex(param_df_sub.index)
-                    
+                    eloss_sub = eloss_df.reindex(param_df_sub.index).fillna(0.0)
+
                     # prepare reservoir DA data
                     (reservoir_usgs_df_sub, 
                      reservoir_usgs_df_time,
@@ -1399,7 +1400,8 @@ def compute_nhd_routing_v02(
 
                 qlat_sub = qlat_sub.reindex(param_df_sub.index)
                 q0_sub = q0_sub.reindex(param_df_sub.index)
-                
+                eloss_sub = eloss_df.reindex(param_df_sub.index).fillna(0.0)
+
                 # prepare reservoir DA data
                 (reservoir_usgs_df_sub, 
                  reservoir_usgs_df_time,
@@ -1602,6 +1604,7 @@ def compute_nhd_routing_v02(
 
             qlat_sub = qlat_sub.reindex(param_df_sub.index)
             q0_sub = q0_sub.reindex(param_df_sub.index)
+            eloss_sub = eloss_df.reindex(param_df_sub.index).fillna(0.0)
             
             # prepare reservoir DA data
             (reservoir_usgs_df_sub, 
@@ -1814,6 +1817,7 @@ def compute_nhd_routing_v02(
 
             qlat_sub = qlat_sub.reindex(np.setdiff1d(param_df_sub.index, offnetwork_upstreams))
             q0_sub = q0_sub.reindex(param_df_sub.index)
+            eloss_sub = eloss_df.reindex(param_df_sub.index).fillna(0.0)
             
             # prepare reservoir DA data
             (reservoir_usgs_df_sub, 

--- a/src/troute-routing/troute/routing/fast_reach/mc_reach.pyx
+++ b/src/troute-routing/troute/routing/fast_reach/mc_reach.pyx
@@ -90,10 +90,16 @@ cdef void compute_reach_kernel(float qup, float quc, int nreach, const float[:,:
     cdef reach.QVD *out = &rv
 
     cdef:
-        float dt, qlat, dx, bw, tw, twcc, n, ncc, cs, s0, qdp, velp, depthp
+        float dt, qlat, qdpp, dx, bw, tw, twcc, n, ncc, cs, s0, qdp, velp, depthp
         int i
 
     for i in range(nreach):
+        # Guard the pre-existing -Wmaybe-uninitialized on qlat/qdpp: the
+        # qlat_add_loc if/elif/elif chain has no else. A no-op for
+        # qlat_add_loc in {0,1,2} (immediately overwritten); deterministic
+        # otherwise.
+        qlat = 0
+        qdpp = 0
         if qlat_add_loc == 0:
             qlat = 0
             qup += input_buf[i, 0]


### PR DESCRIPTION
Three correctness/perf changes in the routing compute path: an
`UnboundLocalError` + empty-`eloss_df` `KeyError` in
`compute_nhd_routing_v02`, a `-Wmaybe-uninitialized` `qlat`/`qdpp` defect in
`compute_reach_kernel`, and a hot per-reach allocation in
`_build_reach_type_list`. Changes are confined to
`src/troute-routing/troute/routing/{compute.py,fast_reach/mc_reach.pyx}`.

## Additions

-

## Removals

-

## Changes

- `compute_nhd_routing_v02`: `eloss_sub` is now assigned in all five
  `parallel_compute_method` branches (`by-subnetwork-jit-clustered`,
  `by-subnetwork-jit`, `by-network`, `serial`, `bmi`) via
  `eloss_df.reindex(param_df_sub.index).fillna(0.0)`. Previously only the
  clustered branch assigned it; the others raised `UnboundLocalError`, and
  the clustered branch's `eloss_df.loc[...]` raised `KeyError` on an empty
  `eloss_df` (the original V3 NHD failure).
- `compute_reach_kernel` (`mc_reach.pyx`): declare `qdpp` (previously
  undeclared in the `cdef` block) and zero-initialise `qlat`/`qdpp` at the
  top of the per-reach loop. The `qlat_add_loc` if/elif/elif chain has no
  `else`, so both could be read uninitialized (`-Wmaybe-uninitialized`). No
  behaviour change for valid `qlat_add_loc`.
- `_build_reach_type_list`: replaced `set(reaches) & wbodies_segs` with
  `wbodies_segs.isdisjoint(reaches)` plus an early return when there are no
  waterbody break segments — no behaviour change, ~13% faster end-to-end on
  the CONUS NHF workload.

## Testing

1. Ran `python -m nwm_routing -V5` on a subset NHF basin (with
   waterbodies + gages) under every `parallel_compute_method`
   (`serial`, `by-network`, `by-subnetwork-jit`,
   `by-subnetwork-jit-clustered`); all complete and produce
   physically-sensible flow/velocity/depth (previously
   `UnboundLocalError` on all but the clustered method).
2. Verified routing output is **bit-identical** before vs. after each
   change on the subset (correctness-preserving for valid inputs).
3. Rebuilt the Cython kernel and re-ran the subset: routing output
   **bit-identical** to baseline (the `qlat`/`qdpp` init is a no-op for
   valid inputs).

## Screenshots


## Notes

- `eloss_df.reindex(...).fillna(0.0)` mirrors the existing clustered-branch
  intent while being defined for every index and robust to an empty
  `eloss_df`.

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the Reviewers tool :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [x] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
