### PR TITLE
fix(routing): guard Muskingum-Cunge kernel against NaN/non-positive channel params

### DIFF
--- a/src/kernel/muskingum/MCsingleSegStime_f2py_NOLOOP.f90
+++ b/src/kernel/muskingum/MCsingleSegStime_f2py_NOLOOP.f90
@@ -1,6 +1,7 @@
 module muskingcunge_module
 
     use precis
+    use, intrinsic :: ieee_arithmetic, only: ieee_is_nan
     implicit none
 
 contains
@@ -61,9 +62,18 @@ subroutine muskingcungenwm(dt, qup, quc, qdp, ql, dx, bw, tw, twcc,&
     endif
 
     !print *, bfd
-    if (n .le. 0.0_prec .or. s0 .le. 0.0_prec .or. z .le. 0.0_prec .or. bw .le. 0.0_prec) then
-        !print*, "Error in channel coefficients -> Muskingum cunge", n, s0, z, bw
-        !call hydro_stop("In MUSKINGCUNGE() - Error in channel coefficients")
+    ! Guard against invalid channel parameters (non-positive or NaN). NaN
+    ! inputs would otherwise propagate through sqrt(s0) into NaN velocity,
+    ! and `.le. 0.0_prec` alone is false for NaN under IEEE 754, so an
+    ! explicit ieee_is_nan check is required. Fail loud rather than
+    ! silently producing zeroed or NaN-tainted output.
+    if (n  .le. 0.0_prec .or. ieee_is_nan(n)  .or. &
+        s0 .le. 0.0_prec .or. ieee_is_nan(s0) .or. &
+        z  .le. 0.0_prec .or. ieee_is_nan(z)  .or. &
+        bw .le. 0.0_prec .or. ieee_is_nan(bw)) then
+        write(*,*) "ERROR: muskingcungenwm received invalid channel parameter " // &
+            "(NaN or non-positive). n=", n, " s0=", s0, " z=", z, " bw=", bw
+        error stop "muskingcungenwm: invalid channel parameter (NaN or non-positive)"
     end if
 
     depthc = max(depthp, 0.0_prec)

--- a/src/troute-network/test/test_nhf_preprocess.py
+++ b/src/troute-network/test/test_nhf_preprocess.py
@@ -1,0 +1,156 @@
+"""Tests for ``troute.nhf_preprocess``.
+
+Covers ``_validate_flowpaths_channel_params`` — the load-time guard that
+rejects ``flowpaths`` containing non-finite (NaN/Inf) channel parameters
+which would otherwise propagate into NaN routing output via ``sqrt(s0)``
+in the Muskingum-Cunge kernel.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from troute.nhf_preprocess import (
+    _BAD_FPID_PREVIEW_LIMIT,
+    _FLOWPATHS_CHANNEL_COLS,
+    _validate_flowpaths_channel_params,
+)
+
+
+def _make_flowpaths(n=5, extra_cols=None):
+    """Build a minimal valid flowpaths DataFrame with all channel cols finite."""
+    data = {c: np.linspace(0.1, 1.0, n) for c in _FLOWPATHS_CHANNEL_COLS}
+    data["fp_id"] = np.arange(1000, 1000 + n)
+    if extra_cols:
+        data.update(extra_cols)
+    return pd.DataFrame(data)
+
+
+# ----- no-op cases ----------------------------------------------------------
+
+def test_validator_none_is_noop():
+    # Must not raise on missing input.
+    _validate_flowpaths_channel_params(None)
+
+
+def test_validator_empty_df_is_noop():
+    _validate_flowpaths_channel_params(pd.DataFrame())
+
+
+def test_validator_no_channel_cols_is_noop():
+    # If none of the kernel-critical columns are present, nothing to validate.
+    df = pd.DataFrame({"fp_id": [1, 2, 3], "something_else": [10.0, 20.0, 30.0]})
+    _validate_flowpaths_channel_params(df)
+
+
+def test_validator_all_finite_passes():
+    df = _make_flowpaths(n=10)
+    _validate_flowpaths_channel_params(df)
+
+
+# ----- raising cases --------------------------------------------------------
+
+def test_validator_raises_on_nan_slope():
+    df = _make_flowpaths(n=4)
+    df.loc[1, "slope"] = np.nan
+    with pytest.raises(ValueError) as excinfo:
+        _validate_flowpaths_channel_params(df)
+    msg = str(excinfo.value)
+    assert "1 of 4 segments" in msg
+    assert "slope" in msg
+    assert "Muskingum-Cunge" in msg
+    # The bad fp_id (1001) must appear in the preview.
+    assert "1001" in msg
+
+
+def test_validator_raises_on_positive_inf():
+    df = _make_flowpaths(n=3)
+    df.loc[2, "n"] = np.inf
+    with pytest.raises(ValueError) as excinfo:
+        _validate_flowpaths_channel_params(df)
+    assert "'n': 1" in str(excinfo.value)
+
+
+def test_validator_raises_on_negative_inf():
+    df = _make_flowpaths(n=3)
+    df.loc[0, "btmwdth"] = -np.inf
+    with pytest.raises(ValueError) as excinfo:
+        _validate_flowpaths_channel_params(df)
+    assert "btmwdth" in str(excinfo.value)
+
+
+def test_validator_reports_multiple_bad_columns():
+    df = _make_flowpaths(n=4)
+    df.loc[0, "slope"] = np.nan
+    df.loc[1, "n"] = np.nan
+    df.loc[2, "topwdth"] = np.inf
+    with pytest.raises(ValueError) as excinfo:
+        _validate_flowpaths_channel_params(df)
+    msg = str(excinfo.value)
+    # 3 distinct affected rows.
+    assert "3 of 4 segments" in msg
+    # Each bad column should be reported individually.
+    assert "'slope': 1" in msg
+    assert "'n': 1" in msg
+    assert "'topwdth': 1" in msg
+
+
+def test_validator_counts_one_row_with_multiple_bad_cols_as_one_segment():
+    # A single row with NaNs in two columns counts as 1 segment (row-wise)
+    # but contributes 1 to each affected-column count.
+    df = _make_flowpaths(n=3)
+    df.loc[1, "slope"] = np.nan
+    df.loc[1, "n"] = np.nan
+    with pytest.raises(ValueError) as excinfo:
+        _validate_flowpaths_channel_params(df)
+    msg = str(excinfo.value)
+    assert "1 of 3 segments" in msg
+    assert "'slope': 1" in msg
+    assert "'n': 1" in msg
+
+
+def test_validator_preview_capped_with_overflow_marker():
+    # More than _BAD_FPID_PREVIEW_LIMIT bad fp_ids → preview is truncated
+    # and the message includes an "(and N more)" marker.
+    n = _BAD_FPID_PREVIEW_LIMIT + 5
+    df = _make_flowpaths(n=n)
+    df.loc[:, "slope"] = np.nan  # mark all rows bad
+    with pytest.raises(ValueError) as excinfo:
+        _validate_flowpaths_channel_params(df)
+    msg = str(excinfo.value)
+    assert f"and {n - _BAD_FPID_PREVIEW_LIMIT} more" in msg
+
+
+def test_validator_handles_missing_fp_id_column():
+    # If fp_id is absent (e.g. test fixture), validation should still raise
+    # but without listing IDs.
+    df = _make_flowpaths(n=3).drop(columns=["fp_id"])
+    df.loc[0, "slope"] = np.nan
+    with pytest.raises(ValueError) as excinfo:
+        _validate_flowpaths_channel_params(df)
+    msg = str(excinfo.value)
+    assert "1 of 3 segments" in msg
+    # Preview list should be empty (no fp_id column to draw from).
+    assert "Affected fp_ids: []" in msg
+
+
+def test_validator_ignores_non_channel_column_nans():
+    # NaN in a column that is NOT a Muskingum-Cunge input should not trigger.
+    df = _make_flowpaths(n=3, extra_cols={"unrelated_col": [1.0, np.nan, 3.0]})
+    _validate_flowpaths_channel_params(df)
+
+
+def test_validator_works_with_partial_channel_columns():
+    # Real geopackages may not contain every entry in _FLOWPATHS_CHANNEL_COLS.
+    # The validator should restrict to whichever subset is present.
+    cols = ["fp_id", "slope", "n"]
+    df = pd.DataFrame({
+        "fp_id": [10, 20, 30],
+        "slope": [0.1, np.nan, 0.3],
+        "n": [0.03, 0.04, 0.05],
+    })
+    with pytest.raises(ValueError) as excinfo:
+        _validate_flowpaths_channel_params(df)
+    msg = str(excinfo.value)
+    assert "'slope': 1" in msg
+    assert "20" in msg

--- a/src/troute-network/troute/nhf_preprocess.py
+++ b/src/troute-network/troute/nhf_preprocess.py
@@ -7,6 +7,43 @@ import pyogrio
 import xarray as xr
 from joblib import Parallel, delayed
 
+# Channel-parameter columns of `flowpaths` consumed by the Muskingum-Cunge
+# kernel. Non-finite (NaN/Inf) values in any of these would propagate
+# into NaN routing output; guard against them at load time and fail loud.
+_FLOWPATHS_CHANNEL_COLS = (
+    "length_km", "n", "slope", "topwdth", "btmwdth",
+    "topwdthcc", "ncc", "chslp", "musx", "musk", "mainstem_lp",
+)
+_BAD_FPID_PREVIEW_LIMIT = 10
+
+
+def _validate_flowpaths_channel_params(flowpaths):
+    """Raise if any MC-kernel channel parameter is non-finite (NaN/Inf)."""
+    if flowpaths is None or flowpaths.empty:
+        return
+    cols = [c for c in _FLOWPATHS_CHANNEL_COLS if c in flowpaths.columns]
+    if not cols:
+        return
+    arr = flowpaths[cols].to_numpy(dtype=float, copy=False, na_value=np.nan)
+    bad_per_col = ~np.isfinite(arr)
+    if not bad_per_col.any():
+        return
+    bad_row_mask = bad_per_col.any(axis=1)
+    bad_count = int(bad_row_mask.sum())
+    per_col = {c: int(bad_per_col[:, i].sum())
+               for i, c in enumerate(cols) if bad_per_col[:, i].any()}
+    bad_fp_ids = (flowpaths.loc[bad_row_mask, "fp_id"].tolist()
+                  if "fp_id" in flowpaths.columns else [])
+    preview = bad_fp_ids[:_BAD_FPID_PREVIEW_LIMIT]
+    more = ("" if len(bad_fp_ids) <= _BAD_FPID_PREVIEW_LIMIT
+            else f" (and {len(bad_fp_ids) - _BAD_FPID_PREVIEW_LIMIT} more)")
+    raise ValueError(
+        f"flowpaths contains {bad_count} of {len(flowpaths)} segments with "
+        f"non-finite (NaN/Inf) channel parameter(s); the Muskingum-Cunge "
+        f"kernel requires finite values. Affected columns: {per_col}. "
+        f"Affected fp_ids{more}: {preview}"
+    )
+
 # Only read relevant areas of NHF to cut down on processing time and memory footprint.
 LAYERS_TO_READ = [
     {
@@ -174,6 +211,7 @@ def read_geo_file(supernetwork_parameters, waterbody_parameters, compute_paramet
     else:
         raise RuntimeError("Unsupported file type: {}".format(file_type))
 
+    _validate_flowpaths_channel_params(table_dict.get("flowpaths"))
     return table_dict
 
 

--- a/src/troute-network/troute/nhf_preprocess.py
+++ b/src/troute-network/troute/nhf_preprocess.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import geopandas as gpd
+import numpy as np
 import pandas as pd
 import pyarrow.parquet as pq
 import pyogrio

--- a/src/troute-routing/test/test_mc_kernel_guard.py
+++ b/src/troute-routing/test/test_mc_kernel_guard.py
@@ -1,0 +1,113 @@
+"""Tests for the Muskingum-Cunge Fortran kernel guard against invalid inputs.
+
+The kernel raises a Fortran ``error stop`` when any of (n, s0, z, bw)
+is NaN or non-positive. Because ``error stop`` terminates the host
+process, each invalid-input case is driven from a child Python
+process and we assert on its exit code and stderr.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+def _run_kernel(snippet: str) -> subprocess.CompletedProcess:
+    """Run a child Python process executing ``snippet`` and return the result.
+
+    The child imports the f2py-compiled Muskingum-Cunge entry point and
+    calls it with the parameters defined in ``snippet``. Any ``error stop``
+    inside the Fortran kernel terminates the child with a non-zero exit
+    code, which is what these tests assert on.
+    """
+    code = textwrap.dedent(
+        """
+        from troute.routing.fast_reach.reach import compute_reach_kernel
+        {snippet}
+        out = compute_reach_kernel(
+            dt, qup, quc, qdp, ql, dx, bw, tw, twcc, n, ncc, cs, s0, velp, depthp,
+        )
+        # If kernel did NOT error_stop, print the result so the parent
+        # test can distinguish "guard tripped" from "guard let bad input through".
+        print('SURVIVED', out)
+        """
+    ).format(snippet=snippet)
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+# Baseline parameters that should route cleanly (no guard trip).
+_VALID_PARAMS = textwrap.dedent(
+    """
+    dt     = 300.0
+    qup    = 0.5
+    quc    = 0.5
+    qdp    = 0.5
+    ql     = 0.01
+    dx     = 1000.0
+    bw     = 10.0
+    tw     = 20.0
+    twcc   = 30.0
+    n      = 0.035
+    ncc    = 0.05
+    cs     = 1.0
+    s0     = 0.001
+    velp   = 0.5
+    depthp = 1.0
+    """
+)
+
+
+def test_kernel_accepts_valid_params():
+    # Sanity check: the harness is wired up correctly and valid inputs
+    # survive the guard.
+    result = _run_kernel(_VALID_PARAMS)
+    assert result.returncode == 0, (
+        f"kernel unexpectedly failed on valid input\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "SURVIVED" in result.stdout
+
+
+_GUARD_MSG = "muskingcungenwm: invalid channel parameter"
+
+
+@pytest.mark.parametrize(
+    "override, label",
+    [
+        ("s0 = float('nan')", "nan_s0"),
+        ("n = float('nan')", "nan_n"),
+        ("bw = float('nan')", "nan_bw"),
+        ("cs = float('nan')", "nan_cs"),  # z = 1/cs → NaN
+        ("s0 = 0.0", "zero_s0"),
+        ("s0 = -0.001", "negative_s0"),
+        ("n = 0.0", "zero_n"),
+        ("n = -0.01", "negative_n"),
+        ("bw = 0.0", "zero_bw"),
+        ("bw = -1.0", "negative_bw"),
+    ],
+    ids=lambda v: v if isinstance(v, str) and not v.startswith("(") else None,
+)
+def test_kernel_error_stops_on_invalid_input(override, label):
+    snippet = _VALID_PARAMS + "\n" + override
+    result = _run_kernel(snippet)
+    # `error stop` terminates with a non-zero exit code.
+    assert result.returncode != 0, (
+        f"[{label}] kernel was expected to error_stop but survived.\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    # The guard message must reach the child stderr/stdout.
+    combined = result.stdout + result.stderr
+    assert _GUARD_MSG in combined, (
+        f"[{label}] expected guard message {_GUARD_MSG!r} in child output.\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    # The child must NOT have reached the post-kernel print.
+    assert "SURVIVED" not in result.stdout, (
+        f"[{label}] kernel did not trip the guard; bad input slipped through."
+    )


### PR DESCRIPTION
## Summary
- Add NaN-aware guard to the Muskingum-Cunge Fortran kernel; previously `.le. 0.0_prec` was false for NaN under IEEE 754, so NaN slope propagated through `sqrt(s0)` into NaN velocity output.
- Kernel now `error stop`s with a descriptive message on bad input instead of silently producing NaN-tainted output.
- Add `_validate_flowpaths_channel_params()` in `nhf_preprocess.read_geo_file` to fail fast at load time with a `ValueError` listing affected columns and fp_ids.

## Test plan
- [ ] Build troute-core succeeds
- [ ] Validator raises clear `ValueError` on inputs containing non-finite channel parameters
- [ ] Validator is a no-op on clean inputs (no false positives)
- [ ] Routing produces no NaN velocity/depth on clean inputs (matches prior output for finite-input segments)