### PR TITLE
64-bit Catchment and Nexus IDs (NGWPC-10861)

### DIFF
--- a/src/troute-bmi/src/troute_nwm_bmi/troute_bmi.py
+++ b/src/troute-bmi/src/troute_nwm_bmi/troute_bmi.py
@@ -105,9 +105,9 @@ class BmiTroute(Bmi):
         super().__init__()
         self._values: dict[str, NDArray] = {
             BmiVars.NGEN_DT: np.array([-1], dtype=np.intc),
-            BmiVars.NEXUS_ID: np.zeros(0, dtype=np.intc),
+            BmiVars.NEXUS_ID: np.zeros(0, dtype=np.int64),
             BmiVars.NEXUS_VALUE: np.zeros(0, dtype=np.double),
-            BmiVars.CATCHMENT_ID: np.zeros(0, dtype=np.intc),
+            BmiVars.CATCHMENT_ID: np.zeros(0, dtype=np.int64),
             BmiVars.CATCHMENT_VALUE: np.zeros(0, dtype=np.double),
             BmiVars.UPSTREAM_ID: np.zeros(0, dtype=int),
             BmiVars.CHANNEL_WATER_ID: np.zeros(0, dtype=np.int64),


### PR DESCRIPTION
Change the BMI's hydrofabric data type to 64-bit integer from 32-bit integer. This is in preparation for an NHF update that will use 64-bit integers for IDs.


## Changes

- Catchment and nexus ID numpy arrays changed from `np.intc` to `np.int64`

## Testing

1. RTE run on WorkSpaces demonstrating T-route still functions.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
