### PR TITLE
Exclude or include or EWTS

### DIFF
--- a/src/model_DAforcing.py
+++ b/src/model_DAforcing.py
@@ -27,9 +27,6 @@ class DAforcing_model():
         """
         
         """
-        # This is required prior to the first log message is issued by t-route.
-        LOG.bind()
-
         __slots__ = ['_data_assimilation_parameters', '_forcing_parameters', '_compute_parameters',
                      '_output_parameters', '_usgs_df', 'reservoir_usgs_df', 'reservoir_usace_df', 
                      '_rfc_timeseries_df', '_lastobs_df', '_t0', '_q0', '_waterbody_df', '_write_lite_restart',


### PR DESCRIPTION
**Majority of these updates were actually merged by Tahir when PR #98 was merged on 6/2/26**

Update to reconfigure a native Python logger to an EWTS logger when the ewts package is installed and the `EWTS_USE_NGEN_BRIDGE` environment variable set by ngen indicates to use ewts for logging.

## Additions

- Call to `configure_existing_logger` when ewts is present and `EWTS_USE_NGEN_BRIDGE` is true
- Logs to stdout follow same format pattern currently used by ewts, <timestamp> <module> <log level> <message>. If log level above INFO, the filename, method name and line number also appended to the log message.

## Removals

- Importing ewts in all modules that log

## Changes

- Change setting `LOG` from the ewts named logger to an Python logger named `TROUTE` 

## Testing

1. Tested with docker build command build argument `USE_EWTS` set `ON` 
2. Tested with docker build command build argument `USE_EWTS` set `OFF`
3. Tested with docker build command build argument `USE_EWTS` not set, which defaults to `ON`