### PR TITLE
feat: recreate aggregated-away wb flowpath links

### DIFF
--- a/src/troute-network/troute/NHF.py
+++ b/src/troute-network/troute/NHF.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor
 import time
 from pathlib import Path
-from pprint import pformat
 from typing import Any
 
 import numpy as np
@@ -101,7 +100,14 @@ class NHF(NHFPreprocessMixin, AbstractNetwork):
 
             # Preprocess network objects
             discretization_len = self.supernetwork_parameters.get("nhf_discretization_len", 300.0)
-            self.preprocess_network(flowpaths, reference_flowpaths, virtual_flowpaths, discretization_len)
+            # Create a list of waterbody associated flowpaths that can be used
+            # to protect waterbody-bearing flowpaths from being aggregated away
+            # during short-reach discretization
+            wb_fp_ids = set(waterbodies["fp_id"].dropna().astype(int).values)
+            self.preprocess_network(
+                flowpaths, reference_flowpaths, virtual_flowpaths,
+                discretization_len, protected_fp_ids=wb_fp_ids,
+            )
 
             self.crosswalk_nex_flowpath_poi(
                 virtual_flowpaths,
@@ -174,13 +180,14 @@ class NHF(NHFPreprocessMixin, AbstractNetwork):
         """Map outlet link_id -> fp_id for reindexing outputs."""
         return self._fp_outlet_crosswalk
 
-    def preprocess_network(self, flowpaths: pd.DataFrame, reference_flowpaths: pd.DataFrame, virtual_flowpaths: pd.DataFrame, discretization_len_m=300.0):
+    def preprocess_network(self, flowpaths: pd.DataFrame, reference_flowpaths: pd.DataFrame, virtual_flowpaths: pd.DataFrame, discretization_len_m=300.0, protected_fp_ids: set[int] | None = None):
         """Create routing links (self._dataframe) and weighting data to assign fp flows to links."""
         self._dataframe, self.nexus_remapping = discretize_flowpaths(
             flowpaths=flowpaths,
             virtual_flowpaths=virtual_flowpaths,
             reference_flowpaths=reference_flowpaths,
             discretization_len_m=discretization_len_m,
+            protected_fp_ids=protected_fp_ids,
         )
         self._connections = None  # Forces recomputation on first call to self.connections
         self._terminal_codes = set(self._dataframe["downstream"]).difference(self._dataframe.index)  # Outlets

--- a/src/troute-network/troute/NHF.py
+++ b/src/troute-network/troute/NHF.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor
 import time
 from pathlib import Path
+from pprint import pformat
 from typing import Any
 
 import numpy as np
@@ -40,8 +41,6 @@ class NHF(NHFPreprocessMixin, AbstractNetwork):
         "_upstream_inflow_df",
         "_nexus_virtual_seg_ids",
         "_fp_outlet_crosswalk",
-        "_fp_id_to_initial_nodes",
-        "_flowpaths_df",
     ]
 
     def __init__(
@@ -183,29 +182,6 @@ class NHF(NHFPreprocessMixin, AbstractNetwork):
             reference_flowpaths=reference_flowpaths,
             discretization_len_m=discretization_len_m,
         )
-        # Build a map from fp_id -> (up_virtual_nex_id, dn_virtual_nex_id, segment_order)
-        # from the pre-aggregation virtual flowpath topology.  This is needed by
-        # _refactor_reservoirs to locate waterbody flowpaths that were merged
-        # away during short-reach aggregation.
-        _vfp = virtual_flowpaths.dropna(subset=["up_virtual_nex_id"]).copy()
-        _vfp["up_virtual_nex_id"] = _vfp["up_virtual_nex_id"].astype(int)
-        _initial = pd.merge(
-            _vfp[["virtual_fp_id", "up_virtual_nex_id", "dn_virtual_nex_id"]],
-            reference_flowpaths[["fp_id", "virtual_fp_id", "segment_order"]].drop_duplicates(),
-            on="virtual_fp_id",
-        )
-        self._fp_id_to_initial_nodes = {
-            int(row["fp_id"]): (
-                int(row["up_virtual_nex_id"]),
-                int(row["dn_virtual_nex_id"]),
-                int(row["segment_order"]),
-            )
-            for _, row in _initial.iterrows()
-        }
-        # Store flowpaths so _refactor_reservoirs can look up channel params
-        # when recreating aggregated-away waterbody links.
-        self._flowpaths_df = flowpaths
-
         self._connections = None  # Forces recomputation on first call to self.connections
         self._terminal_codes = set(self._dataframe["downstream"]).difference(self._dataframe.index)  # Outlets
         self._build_fp_outlet_crosswalk(reference_flowpaths, virtual_flowpaths)

--- a/src/troute-network/troute/NHF.py
+++ b/src/troute-network/troute/NHF.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor
 import time
 from pathlib import Path
-from pprint import pformat
 from typing import Any
 
 import numpy as np
@@ -41,6 +40,8 @@ class NHF(NHFPreprocessMixin, AbstractNetwork):
         "_upstream_inflow_df",
         "_nexus_virtual_seg_ids",
         "_fp_outlet_crosswalk",
+        "_fp_id_to_initial_nodes",
+        "_flowpaths_df",
     ]
 
     def __init__(
@@ -182,6 +183,29 @@ class NHF(NHFPreprocessMixin, AbstractNetwork):
             reference_flowpaths=reference_flowpaths,
             discretization_len_m=discretization_len_m,
         )
+        # Build a map from fp_id -> (up_virtual_nex_id, dn_virtual_nex_id, segment_order)
+        # from the pre-aggregation virtual flowpath topology.  This is needed by
+        # _refactor_reservoirs to locate waterbody flowpaths that were merged
+        # away during short-reach aggregation.
+        _vfp = virtual_flowpaths.dropna(subset=["up_virtual_nex_id"]).copy()
+        _vfp["up_virtual_nex_id"] = _vfp["up_virtual_nex_id"].astype(int)
+        _initial = pd.merge(
+            _vfp[["virtual_fp_id", "up_virtual_nex_id", "dn_virtual_nex_id"]],
+            reference_flowpaths[["fp_id", "virtual_fp_id", "segment_order"]].drop_duplicates(),
+            on="virtual_fp_id",
+        )
+        self._fp_id_to_initial_nodes = {
+            int(row["fp_id"]): (
+                int(row["up_virtual_nex_id"]),
+                int(row["dn_virtual_nex_id"]),
+                int(row["segment_order"]),
+            )
+            for _, row in _initial.iterrows()
+        }
+        # Store flowpaths so _refactor_reservoirs can look up channel params
+        # when recreating aggregated-away waterbody links.
+        self._flowpaths_df = flowpaths
+
         self._connections = None  # Forces recomputation on first call to self.connections
         self._terminal_codes = set(self._dataframe["downstream"]).difference(self._dataframe.index)  # Outlets
         self._build_fp_outlet_crosswalk(reference_flowpaths, virtual_flowpaths)

--- a/src/troute-network/troute/nhf_discretize.py
+++ b/src/troute-network/troute/nhf_discretize.py
@@ -114,6 +114,7 @@ def discretize_flowpaths(
     discretization_len_m: float = 300.0,
     aggregate_short_reaches: bool = True,
     export_links_nodes_gpkg_path: Union[None, str] = None,
+    protected_fp_ids: set[int] | None = None,
 ) -> tuple[pd.DataFrame, dict[int, int], dict[int, int]]:
     """Discretize flowpaths into uniform-length links and resolve short reaches.
 
@@ -168,7 +169,9 @@ def discretize_flowpaths(
     
     links = _load_initial_links(virtual_flowpaths, reference_flowpaths)
     if aggregate_short_reaches:
-        links, merged_node_crosswalk = _aggregate_links(links, discretization_len_m)
+        links, merged_node_crosswalk = _aggregate_links(
+            links, discretization_len_m, protected_fp_ids,
+        )
     else:
         merged_node_crosswalk = {}
     links = _discretize_links(links, discretization_len_m, cur_node_id)  
@@ -286,7 +289,8 @@ def _load_initial_links(
     )
 
 def _aggregate_links(
-    links: LinkArrays, discretization_len_m: float
+    links: LinkArrays, discretization_len_m: float,
+    protected_fp_ids: set[int] | None = None,
 ) -> tuple[LinkArrays, dict[int, int]]:
     """Merge links shorter than threshold into upstream neighbors.
 
@@ -308,6 +312,8 @@ def _aggregate_links(
     short_mask = links.length < discretization_len_m
     has_us = np.array([u in dn_index for u in links.up_node_id], dtype=bool)
     short_mask &= has_us
+    if protected_fp_ids:
+        short_mask &= ~np.isin(links.fp_id, list(protected_fp_ids))
     
     # Mark merged so we can remove them later (currently non removed)
     active = np.ones(len(links.length), dtype=bool)
@@ -323,6 +329,10 @@ def _aggregate_links(
             continue
         length = links.length[idx]
         if length >= discretization_len_m:
+            continue
+        # Never merge away a protected flowpath link. Right now these are
+        # just short flowpaths associated with waterbodies
+        if protected_fp_ids and links.fp_id[idx] in protected_fp_ids:
             continue
         
         # Get link info

--- a/src/troute-network/troute/nhf_preprocess.py
+++ b/src/troute-network/troute/nhf_preprocess.py
@@ -731,7 +731,6 @@ class NHFPreprocessMixin:
         index_vals = []
         skipped_wb: list[int] = []
         nodes_removed: list[int] = []
-        recreated_nodes: set[int] = set()
         downstream_groups = self.dataframe.groupby("downstream").groups
         for outlet_fp, wb_group in self.waterbody_dataframe.groupby("fp_id"):
             # Until this is implemented in NHF, spoof here
@@ -742,59 +741,8 @@ class NHFPreprocessMixin:
             # eliminated in discretization -> nothing to model as a reservoir).
             all_links = links_by_fp.get(outlet_fp)
             if all_links is None:
-                # If the waterbody's flowpath links were aggregated away during
-                # short-reach discretization, try to recreate a synthetic link
-                # from the pre-aggregation virtual-flowpath topology so the
-                # waterbody can still be refactored as a reservoir.
-                fp_to_init = getattr(self, '_fp_id_to_initial_nodes', {})
-                flowpaths_df = getattr(self, '_flowpaths_df', None)
-                if (
-                    outlet_fp in fp_to_init
-                    and flowpaths_df is not None
-                ):
-                    orig_up_nex, orig_dn_nex, seg_order = fp_to_init[outlet_fp]
-                    nexus_remap = getattr(self, 'nexus_remapping', {})
-                    if orig_up_nex in nexus_remap and orig_up_nex not in self.dataframe.index:
-                        fp_rows = flowpaths_df[flowpaths_df['fp_id'] == outlet_fp]
-                        if not fp_rows.empty:
-                            fp_row = fp_rows.iloc[0]
-                            # The downstream nexus may also have been merged away
-                            # during short-reach aggregation; follow the remap
-                            # chain to find the node that survives in the df.
-                            dn_nex = int(orig_dn_nex)
-                            while dn_nex in nexus_remap:
-                                dn_nex = int(nexus_remap[dn_nex])
-                            self.dataframe.loc[int(orig_up_nex)] = {
-                                'fp_id': int(outlet_fp),
-                                'downstream': dn_nex,
-                                'segment_order': int(seg_order),
-                                'dx': float(fp_row['length_km']) * 1000.0,
-                                'n': float(fp_row['n']),
-                                'mainstem': int(fp_row['mainstem_lp']),
-                                'tw': float(fp_row['topwdth']),
-                                's0': float(fp_row['slope']),
-                                'ncc': float(fp_row['ncc']),
-                                'bw': float(fp_row['btmwdth']),
-                                'musx': float(fp_row['musx']),
-                                'cs': float(fp_row['chslp']),
-                                'twcc': float(fp_row['topwdthcc']),
-                                'musk': int(fp_row['musk']),
-                                'alt': 0,
-                            }
-                            # Register the recreated link in the connections
-                            # graph so the pop / rewiring below works.
-                            self._connections[int(orig_up_nex)] = [dn_nex]
-                            # Track this node so it gets a zero-q lat entry
-                            recreated_nodes.add(int(orig_up_nex))
-                            # Refresh links_by_fp for this fp_id so the
-                            # ds_set/us_set check below resolves correctly
-                            links_by_fp[outlet_fp] = self.dataframe[
-                                self.dataframe["fp_id"] == outlet_fp
-                            ].reset_index()
-                            all_links = links_by_fp.get(outlet_fp)
-                if all_links is None:
-                    skipped_wb.extend(wb_group.index.astype(int).tolist())
-                    continue
+                skipped_wb.extend(wb_group.index.astype(int).tolist())
+                continue
             ds_set = set(all_links["downstream"]).difference(all_links["up_node_id"])
             us_set = set(all_links["up_node_id"]).difference(all_links["downstream"])
             if len(ds_set) != 1 or len(us_set) != 1:
@@ -902,16 +850,6 @@ class NHFPreprocessMixin:
         # faster than a comprehension iterating the Index.
         wb_index = self.waterbody_dataframe.index.tolist()
         self.waterbody_connections = dict(zip(wb_index, wb_index))
-
-        # Recreated headwater nodes (from link-recreation in the
-        # aggregated-away-flowpath branch) also need a qlat entry.
-        # They exist in the dataframe but have no vfp_nex_ids mapping,
-        # so the qlat expansion won't produce an entry for them.
-        # Adding them to zero_nodes gives a zero-q lat default.
-        if recreated_nodes:
-            self.zero_nodes = list(
-                set(self.zero_nodes).union(recreated_nodes)
-            )
 
         row_df = pd.DataFrame(df_rows, index=index_vals)
         row_df.index.name = self.dataframe.index.name

--- a/src/troute-network/troute/nhf_preprocess.py
+++ b/src/troute-network/troute/nhf_preprocess.py
@@ -731,6 +731,7 @@ class NHFPreprocessMixin:
         index_vals = []
         skipped_wb: list[int] = []
         nodes_removed: list[int] = []
+        recreated_nodes: set[int] = set()
         downstream_groups = self.dataframe.groupby("downstream").groups
         for outlet_fp, wb_group in self.waterbody_dataframe.groupby("fp_id"):
             # Until this is implemented in NHF, spoof here
@@ -741,8 +742,59 @@ class NHFPreprocessMixin:
             # eliminated in discretization -> nothing to model as a reservoir).
             all_links = links_by_fp.get(outlet_fp)
             if all_links is None:
-                skipped_wb.extend(wb_group.index.astype(int).tolist())
-                continue
+                # If the waterbody's flowpath links were aggregated away during
+                # short-reach discretization, try to recreate a synthetic link
+                # from the pre-aggregation virtual-flowpath topology so the
+                # waterbody can still be refactored as a reservoir.
+                fp_to_init = getattr(self, '_fp_id_to_initial_nodes', {})
+                flowpaths_df = getattr(self, '_flowpaths_df', None)
+                if (
+                    outlet_fp in fp_to_init
+                    and flowpaths_df is not None
+                ):
+                    orig_up_nex, orig_dn_nex, seg_order = fp_to_init[outlet_fp]
+                    nexus_remap = getattr(self, 'nexus_remapping', {})
+                    if orig_up_nex in nexus_remap and orig_up_nex not in self.dataframe.index:
+                        fp_rows = flowpaths_df[flowpaths_df['fp_id'] == outlet_fp]
+                        if not fp_rows.empty:
+                            fp_row = fp_rows.iloc[0]
+                            # The downstream nexus may also have been merged away
+                            # during short-reach aggregation; follow the remap
+                            # chain to find the node that survives in the df.
+                            dn_nex = int(orig_dn_nex)
+                            while dn_nex in nexus_remap:
+                                dn_nex = int(nexus_remap[dn_nex])
+                            self.dataframe.loc[int(orig_up_nex)] = {
+                                'fp_id': int(outlet_fp),
+                                'downstream': dn_nex,
+                                'segment_order': int(seg_order),
+                                'dx': float(fp_row['length_km']) * 1000.0,
+                                'n': float(fp_row['n']),
+                                'mainstem': int(fp_row['mainstem_lp']),
+                                'tw': float(fp_row['topwdth']),
+                                's0': float(fp_row['slope']),
+                                'ncc': float(fp_row['ncc']),
+                                'bw': float(fp_row['btmwdth']),
+                                'musx': float(fp_row['musx']),
+                                'cs': float(fp_row['chslp']),
+                                'twcc': float(fp_row['topwdthcc']),
+                                'musk': int(fp_row['musk']),
+                                'alt': 0,
+                            }
+                            # Register the recreated link in the connections
+                            # graph so the pop / rewiring below works.
+                            self._connections[int(orig_up_nex)] = [dn_nex]
+                            # Track this node so it gets a zero-q lat entry
+                            recreated_nodes.add(int(orig_up_nex))
+                            # Refresh links_by_fp for this fp_id so the
+                            # ds_set/us_set check below resolves correctly
+                            links_by_fp[outlet_fp] = self.dataframe[
+                                self.dataframe["fp_id"] == outlet_fp
+                            ].reset_index()
+                            all_links = links_by_fp.get(outlet_fp)
+                if all_links is None:
+                    skipped_wb.extend(wb_group.index.astype(int).tolist())
+                    continue
             ds_set = set(all_links["downstream"]).difference(all_links["up_node_id"])
             us_set = set(all_links["up_node_id"]).difference(all_links["downstream"])
             if len(ds_set) != 1 or len(us_set) != 1:
@@ -850,6 +902,16 @@ class NHFPreprocessMixin:
         # faster than a comprehension iterating the Index.
         wb_index = self.waterbody_dataframe.index.tolist()
         self.waterbody_connections = dict(zip(wb_index, wb_index))
+
+        # Recreated headwater nodes (from link-recreation in the
+        # aggregated-away-flowpath branch) also need a qlat entry.
+        # They exist in the dataframe but have no vfp_nex_ids mapping,
+        # so the qlat expansion won't produce an entry for them.
+        # Adding them to zero_nodes gives a zero-q lat default.
+        if recreated_nodes:
+            self.zero_nodes = list(
+                set(self.zero_nodes).union(recreated_nodes)
+            )
 
         row_df = pd.DataFrame(df_rows, index=index_vals)
         row_df.index.name = self.dataframe.index.name


### PR DESCRIPTION
When short-reach aggregation fully merges a waterbody's flowpath into its neighbors, _refactor_reservoirs now recreates a synthetic link from the pre-aggregation virtual-flowpath topology so the lake remains routable as a reservoir instead of being demoted to a plain MC channel. The recreated link's downstream node follows the nexus remapping chain to account for cascading merges, and its headwater node is registered as a zero-qlat segment to satisfy the routing kernel's row-completeness check.

I tested this across CONUS with `run_conus_lakes.py` and it seemed to work. The new map between flowpath and virtual_fp_id, dn_nex_id, and up_nex_id does add time to network construction.