### PR TITLE
Apply level-pool routing on virtual flowpaths when a lake feature is present

### DIFF
--- a/src/troute-network/troute/NHF.py
+++ b/src/troute-network/troute/NHF.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor
 import time
 from pathlib import Path
-from pprint import pformat
 from typing import Any
 
 import numpy as np
@@ -42,6 +41,8 @@ class NHF(NHFPreprocessMixin, AbstractNetwork):
         "_upstream_inflow_df",
         "_nexus_virtual_seg_ids",
         "_fp_outlet_crosswalk",
+        "_fp_id_to_initial_nodes",
+        "_flowpaths_df",
     ]
 
     def __init__(
@@ -191,6 +192,29 @@ class NHF(NHFPreprocessMixin, AbstractNetwork):
             reference_flowpaths=reference_flowpaths,
             discretization_len_m=discretization_len_m,
         )
+        # Build a map from fp_id -> (up_virtual_nex_id, dn_virtual_nex_id, segment_order)
+        # from the pre-aggregation virtual flowpath topology.  This is needed by
+        # _refactor_reservoirs to locate waterbody flowpaths that were merged
+        # away during short-reach aggregation.
+        _vfp = virtual_flowpaths.dropna(subset=["up_virtual_nex_id"]).copy()
+        _vfp["up_virtual_nex_id"] = _vfp["up_virtual_nex_id"].astype(int)
+        _initial = pd.merge(
+            _vfp[["virtual_fp_id", "up_virtual_nex_id", "dn_virtual_nex_id"]],
+            reference_flowpaths[["fp_id", "virtual_fp_id", "segment_order"]].drop_duplicates(),
+            on="virtual_fp_id",
+        )
+        self._fp_id_to_initial_nodes = {
+            int(row["fp_id"]): (
+                int(row["up_virtual_nex_id"]),
+                int(row["dn_virtual_nex_id"]),
+                int(row["segment_order"]),
+            )
+            for _, row in _initial.iterrows()
+        }
+        # Store flowpaths so _refactor_reservoirs can look up channel params
+        # when recreating aggregated-away waterbody links.
+        self._flowpaths_df = flowpaths
+
         self._connections = None  # Forces recomputation on first call to self.connections
         self._terminal_codes = set(self._dataframe["downstream"]).difference(self._dataframe.index)  # Outlets
         self._build_fp_outlet_crosswalk(reference_flowpaths, virtual_flowpaths)

--- a/src/troute-network/troute/NHF.py
+++ b/src/troute-network/troute/NHF.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor
 import time
 from pathlib import Path
-from pprint import pformat
 from typing import Any
 
 import numpy as np
@@ -110,7 +109,14 @@ class NHF(NHFPreprocessMixin, AbstractNetwork):
                 virtual_flowpaths, reference_flowpaths, waterbodies
             )
             discretization_len = self.supernetwork_parameters.get("nhf_discretization_len", 300.0)
-            self.preprocess_network(flowpaths, reference_flowpaths, virtual_flowpaths, discretization_len)
+            # Create a list of waterbody associated flowpaths that can be used
+            # to protect waterbody-bearing flowpaths from being aggregated away
+            # during short-reach discretization
+            wb_fp_ids = set(waterbodies["fp_id"].dropna().astype(int).values)
+            self.preprocess_network(
+                flowpaths, reference_flowpaths, virtual_flowpaths,
+                discretization_len, protected_fp_ids=wb_fp_ids,
+            )
 
             self.crosswalk_nex_flowpath_poi(
                 virtual_flowpaths,
@@ -183,13 +189,14 @@ class NHF(NHFPreprocessMixin, AbstractNetwork):
         """Map outlet link_id -> fp_id for reindexing outputs."""
         return self._fp_outlet_crosswalk
 
-    def preprocess_network(self, flowpaths: pd.DataFrame, reference_flowpaths: pd.DataFrame, virtual_flowpaths: pd.DataFrame, discretization_len_m=300.0):
+    def preprocess_network(self, flowpaths: pd.DataFrame, reference_flowpaths: pd.DataFrame, virtual_flowpaths: pd.DataFrame, discretization_len_m=300.0, protected_fp_ids: set[int] | None = None):
         """Create routing links (self._dataframe) and weighting data to assign fp flows to links."""
         self._dataframe, self.nexus_remapping = discretize_flowpaths(
             flowpaths=flowpaths,
             virtual_flowpaths=virtual_flowpaths,
             reference_flowpaths=reference_flowpaths,
             discretization_len_m=discretization_len_m,
+            protected_fp_ids=protected_fp_ids,
         )
         self._connections = None  # Forces recomputation on first call to self.connections
         self._terminal_codes = set(self._dataframe["downstream"]).difference(self._dataframe.index)  # Outlets

--- a/src/troute-network/troute/NHF.py
+++ b/src/troute-network/troute/NHF.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor
 import time
 from pathlib import Path
+from pprint import pformat
 from typing import Any
 
 import numpy as np
@@ -41,8 +42,6 @@ class NHF(NHFPreprocessMixin, AbstractNetwork):
         "_upstream_inflow_df",
         "_nexus_virtual_seg_ids",
         "_fp_outlet_crosswalk",
-        "_fp_id_to_initial_nodes",
-        "_flowpaths_df",
     ]
 
     def __init__(
@@ -192,29 +191,6 @@ class NHF(NHFPreprocessMixin, AbstractNetwork):
             reference_flowpaths=reference_flowpaths,
             discretization_len_m=discretization_len_m,
         )
-        # Build a map from fp_id -> (up_virtual_nex_id, dn_virtual_nex_id, segment_order)
-        # from the pre-aggregation virtual flowpath topology.  This is needed by
-        # _refactor_reservoirs to locate waterbody flowpaths that were merged
-        # away during short-reach aggregation.
-        _vfp = virtual_flowpaths.dropna(subset=["up_virtual_nex_id"]).copy()
-        _vfp["up_virtual_nex_id"] = _vfp["up_virtual_nex_id"].astype(int)
-        _initial = pd.merge(
-            _vfp[["virtual_fp_id", "up_virtual_nex_id", "dn_virtual_nex_id"]],
-            reference_flowpaths[["fp_id", "virtual_fp_id", "segment_order"]].drop_duplicates(),
-            on="virtual_fp_id",
-        )
-        self._fp_id_to_initial_nodes = {
-            int(row["fp_id"]): (
-                int(row["up_virtual_nex_id"]),
-                int(row["dn_virtual_nex_id"]),
-                int(row["segment_order"]),
-            )
-            for _, row in _initial.iterrows()
-        }
-        # Store flowpaths so _refactor_reservoirs can look up channel params
-        # when recreating aggregated-away waterbody links.
-        self._flowpaths_df = flowpaths
-
         self._connections = None  # Forces recomputation on first call to self.connections
         self._terminal_codes = set(self._dataframe["downstream"]).difference(self._dataframe.index)  # Outlets
         self._build_fp_outlet_crosswalk(reference_flowpaths, virtual_flowpaths)

--- a/src/troute-network/troute/NHF.py
+++ b/src/troute-network/troute/NHF.py
@@ -523,7 +523,8 @@ def _force_headwater_routing(
     )
 
     # Force routing on headwater vfps with waterbodies
-    waterbody_vfps = waterbodies.dropna(subset=LEVEL_POOL_PARAMS)["virtual_fp_id"].astype(int).values
+    _required_lp_fields = list(set(LEVEL_POOL_PARAMS).difference(["fp_id"]))
+    waterbody_vfps = waterbodies.dropna(subset=_required_lp_fields)["virtual_fp_id"].astype(int).values
     forced_vfps.extend(list(set(headwater_vfps).intersection(waterbody_vfps)))
 
     # In the future, could add more conditions here

--- a/src/troute-network/troute/NHF.py
+++ b/src/troute-network/troute/NHF.py
@@ -12,6 +12,7 @@ from .AbstractNetwork import AbstractNetwork
 from troute.nhf_discretize import discretize_flowpaths
 
 from troute.nhf_preprocess import (
+    LEVEL_POOL_PARAMS,
     NHFPreprocessMixin,
     read_geo_file,
     read_qlat_file,
@@ -522,7 +523,7 @@ def _force_headwater_routing(
     )
 
     # Force routing on headwater vfps with waterbodies
-    waterbody_vfps = waterbodies["virtual_fp_id"].dropna().astype(int).values
+    waterbody_vfps = waterbodies.dropna(subset=LEVEL_POOL_PARAMS)["virtual_fp_id"].astype(int).values
     forced_vfps.extend(list(set(headwater_vfps).intersection(waterbody_vfps)))
 
     # In the future, could add more conditions here

--- a/src/troute-network/troute/NHF.py
+++ b/src/troute-network/troute/NHF.py
@@ -100,6 +100,14 @@ class NHF(NHFPreprocessMixin, AbstractNetwork):
             hydrolocations = nhf["hydrolocations"]
 
             # Preprocess network objects
+            (
+                virtual_flowpaths,
+                reference_flowpaths,
+                waterbodies,
+                self.div_reverse_lookup,
+            ) = _force_headwater_routing(
+                virtual_flowpaths, reference_flowpaths, waterbodies
+            )
             discretization_len = self.supernetwork_parameters.get("nhf_discretization_len", 300.0)
             self.preprocess_network(flowpaths, reference_flowpaths, virtual_flowpaths, discretization_len)
 
@@ -297,17 +305,26 @@ class NHF(NHFPreprocessMixin, AbstractNetwork):
         # Make weights
         self.weights = np.nan_to_num(vfp_map["percentage_area_contribution"].to_numpy())
 
-        # In case NHF percents per div don't sum to 100, distribute remainder evenly.
+        # Check whether percentage_area_contribution sums close to 100 per div.
         # Factorize div_id to dense 0..K-1 group codes before bincount. div_id may be
         # a large, sparse identifier (NHF >= 1.2.0 ids are ~1e15), and bincount on the
-        # raw values would allocate a max(div_id)-sized array. Indexing the per-group
-        # results back with `codes` is identical to indexing with the raw div_ids, so
-        # the result is unchanged on dense-id datasets (e.g. NHF 1.1.4).
-        codes, _ = pd.factorize(vfp_map["div_id"].astype("int64").to_numpy(), sort=False)
+        # raw values would allocate a max(div_id)-sized array.
+        codes, uniq_divs = pd.factorize(vfp_map["div_id"].astype("int64").to_numpy(), sort=False)
         known_sum = np.bincount(codes, weights=self.weights)
-        vfp_count = np.bincount(codes)
-        share = np.divide(1 - known_sum, vfp_count, out=np.zeros_like(vfp_count, dtype=float), where=vfp_count!=0)
-        self.weights += share[codes]
+
+        # Warn about divs whose weights don't sum near 1 and are not forced-routing headwaters
+        forced_ids = set(self.div_reverse_lookup.keys()) | set(self.div_reverse_lookup.values())
+        bad_mask = ~np.isclose(known_sum, 1.0, atol=0.01)
+        bad_divs = [int(uniq_divs[i]) for i in np.where(bad_mask)[0] if int(uniq_divs[i]) not in forced_ids]
+        if bad_divs:
+            LOG.warning(
+                "%d div_id(s) have percentage_area_contribution that does not sum close to 100 "
+                "(and are not forced-routing headwaters), e.g. %s",
+                len(bad_divs), bad_divs[:10]
+            )
+
+        # Reverse temporary div_id assignment for any forced-routing headwaters
+        vfp_map["div_id"] = vfp_map["div_id"].replace(self.div_reverse_lookup)
 
         # Set class variables
         self.vfp_nex_ids = vfp_map["up_node_id"].to_numpy()
@@ -482,3 +499,70 @@ class NHF(NHFPreprocessMixin, AbstractNetwork):
             self._usace_lake_gage_crosswalk = inputs.get("usace_lake_gage_crosswalk", None)
             self._usbr_lake_gage_crosswalk = inputs.get("usbr_lake_gage_crosswalk", None)
             self._rfc_lake_gage_crosswalk = inputs.get("rfc_lake_gage_crosswalk", None)
+
+
+def _force_headwater_routing(
+    virtual_flowpaths: pd.DataFrame,
+    reference_flowpaths: pd.DataFrame,
+    waterbodies: pd.DataFrame,
+) -> pd.DataFrame:
+    """Modify datasets such that routing can be performed on headwater virtual flowpaths.
+
+    This functionality is currently implemented for waterbodies on virtual
+    flowpaths, but it could be used for gages as well.
+    """
+    # Establish eligible headwaters.
+    forced_vfps = []
+    headwater_vfps = (
+        virtual_flowpaths[virtual_flowpaths["up_virtual_nex_id"].isna()][
+            "virtual_fp_id"
+        ]
+        .astype(int)
+        .values
+    )
+
+    # Force routing on headwater vfps with waterbodies
+    waterbody_vfps = waterbodies["virtual_fp_id"].dropna().astype(int).values
+    forced_vfps.extend(list(set(headwater_vfps).intersection(waterbody_vfps)))
+
+    # In the future, could add more conditions here
+
+    ### Modify datasets ###
+    # Add new up_virtual_nex_id so that vfps won't be dropped in network refactor.
+    max_up_id = int(virtual_flowpaths["up_virtual_nex_id"].max()) + 1
+    new_ids = np.arange(max_up_id, max_up_id + len(forced_vfps))
+    virtual_flowpaths.loc[
+        virtual_flowpaths["virtual_fp_id"].astype(int).isin(forced_vfps),
+        "up_virtual_nex_id",
+    ] = new_ids
+
+    # Assign each headwater its own temporary div_id.
+    # This must be done because the current conceptual model assumes that
+    # there confluences in a div. This comes up in _build_div_weighting_matrix
+    # Where having multiple options for up_node_id will confuse the lat
+    # placement.
+    max_div_id = int(reference_flowpaths["div_id"].max()) + 1
+    new_div_mapping = {vfp: max_div_id + ind for ind, vfp in enumerate(forced_vfps)}
+    force_mask = reference_flowpaths["virtual_fp_id"].astype(int).isin(forced_vfps)
+    reference_flowpaths.loc[force_mask, "new_div_id"] = reference_flowpaths.loc[
+        force_mask, "virtual_fp_id"
+    ].map(new_div_mapping)
+    reference_flowpaths.loc[force_mask, "fp_id"] = reference_flowpaths.loc[
+        force_mask, "virtual_fp_id"
+    ].map(new_div_mapping)
+    div_reverse_lookup = (
+        reference_flowpaths.loc[force_mask, ["new_div_id", "div_id"]]
+        .astype(int)
+        .set_index("new_div_id")["div_id"]
+        .to_dict()
+    )
+    reference_flowpaths.loc[force_mask, "div_id"] = reference_flowpaths.loc[
+        force_mask, "new_div_id"
+    ]
+    reference_flowpaths = reference_flowpaths.drop(columns="new_div_id")
+
+    force_mask = waterbodies["virtual_fp_id"].astype("Int64").isin(forced_vfps)
+    waterbodies.loc[force_mask, "fp_id"] = waterbodies.loc[
+        force_mask, "virtual_fp_id"
+    ].map(new_div_mapping)
+    return virtual_flowpaths, reference_flowpaths, waterbodies, div_reverse_lookup

--- a/src/troute-network/troute/nhf_discretize.py
+++ b/src/troute-network/troute/nhf_discretize.py
@@ -59,6 +59,7 @@ class LinkArrays:
     """
 
     fp_id: np.ndarray
+    vfp_id: np.ndarray
     dn_node_id: np.ndarray
     up_node_id: np.ndarray
     length: np.ndarray
@@ -69,6 +70,7 @@ class LinkArrays:
         """Load LinksArrays from a virtual flowpaths layer."""
         return cls(
             df[FIELD_FP_ID].to_numpy().astype(int),
+            df[FIELD_VIRTUAL_FP_ID].to_numpy().astype(int),
             df[FIELD_DN_VIRTUAL_NEX_ID].to_numpy().astype(int),
             df[FIELD_UP_VIRTUAL_NEX_ID].to_numpy().astype(int),
             df[FIELD_LENGTH].to_numpy() * FIELD_LENGTH_CONVERSION,
@@ -91,6 +93,7 @@ class LinkArrays:
     def filter(self, mask: np.ndarray) -> None:
         """Keep masked links."""
         self.fp_id = self.fp_id[mask]
+        self.vfp_id = self.vfp_id[mask]
         self.dn_node_id = self.dn_node_id[mask]
         self.up_node_id = self.up_node_id[mask]
         self.length = self.length[mask]
@@ -99,6 +102,7 @@ class LinkArrays:
     def remove(self, ind: int) -> None:
         """Remove a specific index from all arrays."""
         self.fp_id = np.delete(self.fp_id, ind)
+        self.vfp_id = np.delete(self.vfp_id, ind)
         self.dn_node_id = np.delete(self.dn_node_id, ind)
         self.up_node_id = np.delete(self.up_node_id, ind)
         self.length = np.delete(self.length, ind)
@@ -248,11 +252,12 @@ def export_links_and_nodes(
     sorted_ups = links.up_node_id[idx_lookup]
     link_idxs = np.searchsorted(sorted_ups, up_node_ids)
     fp_ids = links.fp_id[idx_lookup[link_idxs]]
+    vfp_ids = links.vfp_id[idx_lookup[link_idxs]]
     segment_order = links.segment_order[idx_lookup[link_idxs]]
 
     # Export geopackage
     gpd.GeoDataFrame(
-        {"up_node_id": up_node_ids, "dn_node_id": dn_node_ids, "fp_id": fp_ids, "segment_order": segment_order},
+        {"up_node_id": up_node_ids, "dn_node_id": dn_node_ids, "fp_id": fp_ids, "vfp_ids": vfp_ids, "segment_order": segment_order},
         geometry=link_geometries,
         crs=virtual_flowpaths.crs,
     ).to_file(export_links_nodes_gpkg_path, layer="links")
@@ -274,9 +279,11 @@ def _load_initial_links(
     virtual_flowpaths: gpd.GeoDataFrame,
     reference_flowpaths: pd.DataFrame,
 ):
+    # Drop headwater vfps
     tmp_vfp = virtual_flowpaths.dropna(subset=FIELD_UP_VIRTUAL_NEX_ID).copy()
     tmp_vfp[FIELD_UP_VIRTUAL_NEX_ID] = tmp_vfp[FIELD_UP_VIRTUAL_NEX_ID].astype(int)
 
+    # Make LinkArray object
     return LinkArrays.from_df(
         pd.merge(
             tmp_vfp,
@@ -392,6 +399,7 @@ def _discretize_links(
     # Pull long-link slices once
     long_length = links.length[long_mask]
     long_fp_id = links.fp_id[long_mask]
+    long_vfp_id = links.vfp_id[long_mask]
     long_up = links.up_node_id[long_mask]
     long_dn = links.dn_node_id[long_mask]
     long_order = links.segment_order[long_mask]
@@ -410,6 +418,7 @@ def _discretize_links(
 
     # Scalar attributes propagate by repeat/index
     subdiv_fp_id = np.repeat(long_fp_id, n)
+    subdiv_vfp_id = np.repeat(long_vfp_id, n)
     subdiv_length = np.repeat(new_len, n)
     subdiv_order = long_order[group] + local_j / n[group]
 
@@ -447,12 +456,13 @@ def _discretize_links(
     # Concat kept-as-is short/medium links with the freshly-subdivided sub-links
     keep_mask = ~long_mask
     link_fp_id = np.concatenate([links.fp_id[keep_mask], subdiv_fp_id])
+    link_vfp_id = np.concatenate([links.vfp_id[keep_mask], subdiv_vfp_id])
     length = np.concatenate([links.length[keep_mask], subdiv_length])
     up_node_id = np.concatenate([links.up_node_id[keep_mask], subdiv_up_node])
     dn_node_id = np.concatenate([links.dn_node_id[keep_mask], subdiv_dn_node])
     segment_order = np.concatenate([links.segment_order[keep_mask], subdiv_order])
 
-    return LinkArrays(link_fp_id, dn_node_id, up_node_id, length, segment_order)
+    return LinkArrays(link_fp_id, link_vfp_id, dn_node_id, up_node_id, length, segment_order)
 
 def _format_link_df(links: LinkArrays, flowpaths: pd.DataFrame) -> pd.DataFrame:
     """Conform to AbstractNetwork format and build mapping from link id to fp_id."""

--- a/src/troute-network/troute/nhf_discretize.py
+++ b/src/troute-network/troute/nhf_discretize.py
@@ -118,6 +118,7 @@ def discretize_flowpaths(
     discretization_len_m: float = 300.0,
     aggregate_short_reaches: bool = True,
     export_links_nodes_gpkg_path: Union[None, str] = None,
+    protected_fp_ids: set[int] | None = None,
 ) -> tuple[pd.DataFrame, dict[int, int], dict[int, int]]:
     """Discretize flowpaths into uniform-length links and resolve short reaches.
 
@@ -172,7 +173,9 @@ def discretize_flowpaths(
     
     links = _load_initial_links(virtual_flowpaths, reference_flowpaths)
     if aggregate_short_reaches:
-        links, merged_node_crosswalk = _aggregate_links(links, discretization_len_m)
+        links, merged_node_crosswalk = _aggregate_links(
+            links, discretization_len_m, protected_fp_ids,
+        )
     else:
         merged_node_crosswalk = {}
     links = _discretize_links(links, discretization_len_m, cur_node_id)  
@@ -293,7 +296,8 @@ def _load_initial_links(
     )
 
 def _aggregate_links(
-    links: LinkArrays, discretization_len_m: float
+    links: LinkArrays, discretization_len_m: float,
+    protected_fp_ids: set[int] | None = None,
 ) -> tuple[LinkArrays, dict[int, int]]:
     """Merge links shorter than threshold into upstream neighbors.
 
@@ -315,6 +319,8 @@ def _aggregate_links(
     short_mask = links.length < discretization_len_m
     has_us = np.array([u in dn_index for u in links.up_node_id], dtype=bool)
     short_mask &= has_us
+    if protected_fp_ids:
+        short_mask &= ~np.isin(links.fp_id, list(protected_fp_ids))
     
     # Mark merged so we can remove them later (currently non removed)
     active = np.ones(len(links.length), dtype=bool)
@@ -330,6 +336,10 @@ def _aggregate_links(
             continue
         length = links.length[idx]
         if length >= discretization_len_m:
+            continue
+        # Never merge away a protected flowpath link. Right now these are
+        # just short flowpaths associated with waterbodies
+        if protected_fp_ids and links.fp_id[idx] in protected_fp_ids:
             continue
         
         # Get link info

--- a/src/troute-network/troute/nhf_preprocess.py
+++ b/src/troute-network/troute/nhf_preprocess.py
@@ -28,6 +28,20 @@ _FLOWPATHS_CHANNEL_COLS = (
 )
 _BAD_FPID_PREVIEW_LIMIT = 10
 LAKE_ID_FIELD = "lake_id"
+LEVEL_POOL_PARAMS = [
+                LAKE_ID_FIELD,
+                "fp_id",
+                "virtual_fp_id",
+                "ifd",
+                "LkArea",
+                "LkMxE",
+                "OrificeA",
+                "OrificeC",
+                "OrificeE",
+                "WeirC",
+                "WeirE",
+                "WeirL",
+            ]
 
 def _validate_flowpaths_channel_params(flowpaths):
     """Raise if any MC-kernel channel parameter is non-finite (NaN/Inf)."""
@@ -587,20 +601,7 @@ class NHFPreprocessMixin:
         if not lakes.empty:
             # Step-by-step cleanup; every dropped category is counted and logged
             # as a warning (see _clean_waterbodies).
-            self.waterbody_dataframe = lakes[[
-                LAKE_ID_FIELD,
-                "fp_id",
-                "virtual_fp_id",
-                "ifd",
-                "LkArea",
-                "LkMxE",
-                "OrificeA",
-                "OrificeC",
-                "OrificeE",
-                "WeirC",
-                "WeirE",
-                "WeirL",
-            ]]
+            self.waterbody_dataframe = lakes[LEVEL_POOL_PARAMS]
             self._waterbody_df, gl_df = _clean_waterbodies(
                 self._waterbody_df, LAKE_ID_FIELD
             )

--- a/src/troute-network/troute/nhf_preprocess.py
+++ b/src/troute-network/troute/nhf_preprocess.py
@@ -27,7 +27,7 @@ _FLOWPATHS_CHANNEL_COLS = (
     "topwdthcc", "ncc", "chslp", "musx", "musk", "mainstem_lp",
 )
 _BAD_FPID_PREVIEW_LIMIT = 10
-
+LAKE_ID_FIELD = "lake_id"
 
 def _validate_flowpaths_channel_params(flowpaths):
     """Raise if any MC-kernel channel parameter is non-finite (NaN/Inf)."""
@@ -145,7 +145,11 @@ LAYERS_TO_READ: list[tuple[str, Optional[list[str]], bool]] = [
         False,
     ),
     ("virtual_nexus", None, True),
-    ("lakes", None, True),
+    (
+        "lakes", 
+        [LAKE_ID_FIELD, "fp_id", "virtual_fp_id", "ifd", "LkArea", "LkMxE", "OrificeA",
+         "OrificeC", "OrificeE", "WeirC", "WeirE", "WeirL", "hy_id", "ref_fp_id"], 
+        True),
     ("gages", None, True),
     ("hydrolocations", None, True),
 ]
@@ -446,12 +450,12 @@ def _clean_waterbodies(
         )
         waterbody_df = waterbody_df[~bad_elev]
 
-    # 5. fp_id anchoring
-    fp_na = waterbody_df["fp_id"].isna()
+    # 5. virtual_fp_id anchoring
+    fp_na = waterbody_df["virtual_fp_id"].isna()
     n_no_fp = int(fp_na.sum())
     if n_no_fp:
         LOG.warning(
-            "waterbodies: dropped %d lakes with no fp_id (cannot be anchored "
+            "waterbodies: dropped %d lakes with no virtual_fp_id (cannot be anchored "
             "to a routing flowpath)", n_no_fp,
         )
         waterbody_df = waterbody_df[~fp_na]
@@ -467,7 +471,7 @@ def _clean_waterbodies(
         )
 
     waterbody_df = waterbody_df.copy()
-    waterbody_df["fp_id"] = waterbody_df["fp_id"].astype(int)
+    waterbody_df["virtual_fp_id"] = waterbody_df["virtual_fp_id"].astype(int)
     summary = (
         "waterbodies: %d of %d lakes retained for reservoir routing",
         len(waterbody_df), n_raw,
@@ -581,33 +585,30 @@ class NHFPreprocessMixin:
 
     def preprocess_waterbodies(self, lakes):
         if not lakes.empty:
-            # Formate waterbodies df
-            lake_id_field = "lake_id"
-            self._waterbody_df = lakes[
-                [
-                    lake_id_field,
-                    "fp_id",
-                    "ifd",
-                    "LkArea",
-                    "LkMxE",
-                    "OrificeA",
-                    "OrificeC",
-                    "OrificeE",
-                    "WeirC",
-                    "WeirE",
-                    "WeirL",
-                ]
-            ].copy()
             # Step-by-step cleanup; every dropped category is counted and logged
             # as a warning (see _clean_waterbodies).
+            self.waterbody_dataframe = lakes[[
+                LAKE_ID_FIELD,
+                "fp_id",
+                "virtual_fp_id",
+                "ifd",
+                "LkArea",
+                "LkMxE",
+                "OrificeA",
+                "OrificeC",
+                "OrificeE",
+                "WeirC",
+                "WeirE",
+                "WeirL",
+            ]]
             self._waterbody_df, gl_df = _clean_waterbodies(
-                self._waterbody_df, lake_id_field
+                self._waterbody_df, LAKE_ID_FIELD
             )
 
             # Add a large value to the lake_ids to create synthetic IDs and avoid conflicts.
             max_df_id = max(self.dataframe.index) + 1 if not self.dataframe.index.empty else 0
             self._waterbody_df.index = np.arange(len(self._waterbody_df)) + max_df_id
-            self._waterbody_df = self._waterbody_df.rename_axis(lake_id_field)
+            self._waterbody_df = self._waterbody_df.rename_axis(LAKE_ID_FIELD)
             self._duplicate_ids_df = pd.DataFrame()  # Relic from how hyfeatures and NHD handled this. We add relationship to _fp_outlet_crosswalk 
 
             # Process great lakes reaches, if necessary
@@ -628,7 +629,7 @@ class NHFPreprocessMixin:
                 self.great_lakes_climatology_df = pd.DataFrame()
 
             # Condense flowpaths in a reservoir to single level pool node
-            self._refactor_reservoirs(lake_id_field)
+            self._refactor_reservoirs()
 
             # Add lat, lon, and crs columns for LAKEOUT files:
             lakeout = self.output_parameters.get("lakeout_output", None)
@@ -679,7 +680,7 @@ class NHFPreprocessMixin:
 
 
     
-    def _refactor_reservoirs(self, lake_id_field: str = "lake_id"):
+    def _refactor_reservoirs(self):
         """Refactor network connectivity to explicitly represent reservoirs (waterbodies) and their interactions with flowpaths and links.
 
         Conceptual model:
@@ -710,11 +711,12 @@ class NHFPreprocessMixin:
         # original code re-scanned the full (multi-million-row) link table with
         # `self.dataframe["fp_id"].isin(...)` and dropped from it once per
         # waterbody -- O(n_links x n_waterbodies), tens of minutes at CONUS. A
-        # waterbody's links are exactly the links whose fp_id == its fp_id, so one
-        # isin (restricted to waterbody fps) plus one groupby gives an O(1) lookup.
-        wb_fp_ids = set(self.waterbody_dataframe["fp_id"].dropna())
-        wb_links = self.dataframe[self.dataframe["fp_id"].isin(wb_fp_ids)].reset_index()
-        links_by_fp = {fp: sub for fp, sub in wb_links.groupby("fp_id")}
+        # waterbody's links are exactly the links whose virtual_fp_id == its 
+        # virtual_fp_id, so one isin (restricted to waterbody virtual_fp_ids) 
+        # plus one groupby gives an O(1) lookup.
+        wb_vfp_ids = set(self.waterbody_dataframe["virtual_fp_id"].dropna())
+        wb_links = self.dataframe[self.dataframe["vfp_id"].isin(wb_vfp_ids)].reset_index()
+        links_by_vfp = {vfp: sub for vfp, sub in wb_links.groupby("vfp_id")}
 
         # Build the connections graph from the full link table up front so the
         # per-waterbody pops below are uniform; dataframe / zero_nodes removals are
@@ -732,14 +734,14 @@ class NHFPreprocessMixin:
         skipped_wb: list[int] = []
         nodes_removed: list[int] = []
         downstream_groups = self.dataframe.groupby("downstream").groups
-        for outlet_fp, wb_group in self.waterbody_dataframe.groupby("fp_id"):
+        for outlet_vfp, wb_group in self.waterbody_dataframe.groupby("virtual_fp_id"):
             # Until this is implemented in NHF, spoof here
             wb_group["lake_order"] = np.arange(len(wb_group))
             wb_group = wb_group.sort_values("lake_order")
 
             # Routing links of this waterbody's flowpath (None if its flowpath was
             # eliminated in discretization -> nothing to model as a reservoir).
-            all_links = links_by_fp.get(outlet_fp)
+            all_links = links_by_vfp.get(outlet_vfp)
             if all_links is None:
                 skipped_wb.extend(wb_group.index.astype(int).tolist())
                 continue
@@ -774,11 +776,13 @@ class NHFPreprocessMixin:
                 self.connections[i] = [ds]
 
             # Add synthetic headwater reach
-            headwater = all_links[all_links["fp_id"] == outlet_fp].iloc[0]
+            headwater = all_links[all_links["vfp_id"] == outlet_vfp].iloc[0]
             head_id = int(headwater["up_node_id"])
             self.connections[head_id] = [ds]
             headwater["downstream"] = ds
-            row = headwater.drop(labels="up_node_id").to_dict()
+            # Ensure MC kernel won't crash on these reaches
+            # TODO: Figure out a way to avoid routing on headwaters altogether.
+            row = headwater.drop(labels="up_node_id").fillna(9999).to_dict()
             df_rows.append(row)
             index_vals.append(head_id)
 

--- a/src/troute-network/troute/nhf_preprocess.py
+++ b/src/troute-network/troute/nhf_preprocess.py
@@ -733,6 +733,7 @@ class NHFPreprocessMixin:
         index_vals = []
         skipped_wb: list[int] = []
         nodes_removed: list[int] = []
+        recreated_nodes: set[int] = set()
         downstream_groups = self.dataframe.groupby("downstream").groups
         for outlet_vfp, wb_group in self.waterbody_dataframe.groupby("virtual_fp_id"):
             # Until this is implemented in NHF, spoof here
@@ -743,8 +744,59 @@ class NHFPreprocessMixin:
             # eliminated in discretization -> nothing to model as a reservoir).
             all_links = links_by_vfp.get(outlet_vfp)
             if all_links is None:
-                skipped_wb.extend(wb_group.index.astype(int).tolist())
-                continue
+                # If the waterbody's flowpath links were aggregated away during
+                # short-reach discretization, try to recreate a synthetic link
+                # from the pre-aggregation virtual-flowpath topology so the
+                # waterbody can still be refactored as a reservoir.
+                fp_to_init = getattr(self, '_fp_id_to_initial_nodes', {})
+                flowpaths_df = getattr(self, '_flowpaths_df', None)
+                if (
+                    outlet_fp in fp_to_init
+                    and flowpaths_df is not None
+                ):
+                    orig_up_nex, orig_dn_nex, seg_order = fp_to_init[outlet_fp]
+                    nexus_remap = getattr(self, 'nexus_remapping', {})
+                    if orig_up_nex in nexus_remap and orig_up_nex not in self.dataframe.index:
+                        fp_rows = flowpaths_df[flowpaths_df['fp_id'] == outlet_fp]
+                        if not fp_rows.empty:
+                            fp_row = fp_rows.iloc[0]
+                            # The downstream nexus may also have been merged away
+                            # during short-reach aggregation; follow the remap
+                            # chain to find the node that survives in the df.
+                            dn_nex = int(orig_dn_nex)
+                            while dn_nex in nexus_remap:
+                                dn_nex = int(nexus_remap[dn_nex])
+                            self.dataframe.loc[int(orig_up_nex)] = {
+                                'fp_id': int(outlet_fp),
+                                'downstream': dn_nex,
+                                'segment_order': int(seg_order),
+                                'dx': float(fp_row['length_km']) * 1000.0,
+                                'n': float(fp_row['n']),
+                                'mainstem': int(fp_row['mainstem_lp']),
+                                'tw': float(fp_row['topwdth']),
+                                's0': float(fp_row['slope']),
+                                'ncc': float(fp_row['ncc']),
+                                'bw': float(fp_row['btmwdth']),
+                                'musx': float(fp_row['musx']),
+                                'cs': float(fp_row['chslp']),
+                                'twcc': float(fp_row['topwdthcc']),
+                                'musk': int(fp_row['musk']),
+                                'alt': 0,
+                            }
+                            # Register the recreated link in the connections
+                            # graph so the pop / rewiring below works.
+                            self._connections[int(orig_up_nex)] = [dn_nex]
+                            # Track this node so it gets a zero-q lat entry
+                            recreated_nodes.add(int(orig_up_nex))
+                            # Refresh links_by_fp for this fp_id so the
+                            # ds_set/us_set check below resolves correctly
+                            links_by_fp[outlet_fp] = self.dataframe[
+                                self.dataframe["fp_id"] == outlet_fp
+                            ].reset_index()
+                            all_links = links_by_fp.get(outlet_fp)
+                if all_links is None:
+                    skipped_wb.extend(wb_group.index.astype(int).tolist())
+                    continue
             ds_set = set(all_links["downstream"]).difference(all_links["up_node_id"])
             us_set = set(all_links["up_node_id"]).difference(all_links["downstream"])
             if len(ds_set) != 1 or len(us_set) != 1:
@@ -854,6 +906,16 @@ class NHFPreprocessMixin:
         # faster than a comprehension iterating the Index.
         wb_index = self.waterbody_dataframe.index.tolist()
         self.waterbody_connections = dict(zip(wb_index, wb_index))
+
+        # Recreated headwater nodes (from link-recreation in the
+        # aggregated-away-flowpath branch) also need a qlat entry.
+        # They exist in the dataframe but have no vfp_nex_ids mapping,
+        # so the qlat expansion won't produce an entry for them.
+        # Adding them to zero_nodes gives a zero-q lat default.
+        if recreated_nodes:
+            self.zero_nodes = list(
+                set(self.zero_nodes).union(recreated_nodes)
+            )
 
         row_df = pd.DataFrame(df_rows, index=index_vals)
         row_df.index.name = self.dataframe.index.name

--- a/src/troute-network/troute/nhf_preprocess.py
+++ b/src/troute-network/troute/nhf_preprocess.py
@@ -733,7 +733,6 @@ class NHFPreprocessMixin:
         index_vals = []
         skipped_wb: list[int] = []
         nodes_removed: list[int] = []
-        recreated_nodes: set[int] = set()
         downstream_groups = self.dataframe.groupby("downstream").groups
         for outlet_vfp, wb_group in self.waterbody_dataframe.groupby("virtual_fp_id"):
             # Until this is implemented in NHF, spoof here
@@ -744,59 +743,8 @@ class NHFPreprocessMixin:
             # eliminated in discretization -> nothing to model as a reservoir).
             all_links = links_by_vfp.get(outlet_vfp)
             if all_links is None:
-                # If the waterbody's flowpath links were aggregated away during
-                # short-reach discretization, try to recreate a synthetic link
-                # from the pre-aggregation virtual-flowpath topology so the
-                # waterbody can still be refactored as a reservoir.
-                fp_to_init = getattr(self, '_fp_id_to_initial_nodes', {})
-                flowpaths_df = getattr(self, '_flowpaths_df', None)
-                if (
-                    outlet_fp in fp_to_init
-                    and flowpaths_df is not None
-                ):
-                    orig_up_nex, orig_dn_nex, seg_order = fp_to_init[outlet_fp]
-                    nexus_remap = getattr(self, 'nexus_remapping', {})
-                    if orig_up_nex in nexus_remap and orig_up_nex not in self.dataframe.index:
-                        fp_rows = flowpaths_df[flowpaths_df['fp_id'] == outlet_fp]
-                        if not fp_rows.empty:
-                            fp_row = fp_rows.iloc[0]
-                            # The downstream nexus may also have been merged away
-                            # during short-reach aggregation; follow the remap
-                            # chain to find the node that survives in the df.
-                            dn_nex = int(orig_dn_nex)
-                            while dn_nex in nexus_remap:
-                                dn_nex = int(nexus_remap[dn_nex])
-                            self.dataframe.loc[int(orig_up_nex)] = {
-                                'fp_id': int(outlet_fp),
-                                'downstream': dn_nex,
-                                'segment_order': int(seg_order),
-                                'dx': float(fp_row['length_km']) * 1000.0,
-                                'n': float(fp_row['n']),
-                                'mainstem': int(fp_row['mainstem_lp']),
-                                'tw': float(fp_row['topwdth']),
-                                's0': float(fp_row['slope']),
-                                'ncc': float(fp_row['ncc']),
-                                'bw': float(fp_row['btmwdth']),
-                                'musx': float(fp_row['musx']),
-                                'cs': float(fp_row['chslp']),
-                                'twcc': float(fp_row['topwdthcc']),
-                                'musk': int(fp_row['musk']),
-                                'alt': 0,
-                            }
-                            # Register the recreated link in the connections
-                            # graph so the pop / rewiring below works.
-                            self._connections[int(orig_up_nex)] = [dn_nex]
-                            # Track this node so it gets a zero-q lat entry
-                            recreated_nodes.add(int(orig_up_nex))
-                            # Refresh links_by_fp for this fp_id so the
-                            # ds_set/us_set check below resolves correctly
-                            links_by_fp[outlet_fp] = self.dataframe[
-                                self.dataframe["fp_id"] == outlet_fp
-                            ].reset_index()
-                            all_links = links_by_fp.get(outlet_fp)
-                if all_links is None:
-                    skipped_wb.extend(wb_group.index.astype(int).tolist())
-                    continue
+                skipped_wb.extend(wb_group.index.astype(int).tolist())
+                continue
             ds_set = set(all_links["downstream"]).difference(all_links["up_node_id"])
             us_set = set(all_links["up_node_id"]).difference(all_links["downstream"])
             if len(ds_set) != 1 or len(us_set) != 1:
@@ -906,16 +854,6 @@ class NHFPreprocessMixin:
         # faster than a comprehension iterating the Index.
         wb_index = self.waterbody_dataframe.index.tolist()
         self.waterbody_connections = dict(zip(wb_index, wb_index))
-
-        # Recreated headwater nodes (from link-recreation in the
-        # aggregated-away-flowpath branch) also need a qlat entry.
-        # They exist in the dataframe but have no vfp_nex_ids mapping,
-        # so the qlat expansion won't produce an entry for them.
-        # Adding them to zero_nodes gives a zero-q lat default.
-        if recreated_nodes:
-            self.zero_nodes = list(
-                set(self.zero_nodes).union(recreated_nodes)
-            )
 
         row_df = pd.DataFrame(df_rows, index=index_vals)
         row_df.index.name = self.dataframe.index.name

--- a/src/troute-network/troute/nhf_preprocess.py
+++ b/src/troute-network/troute/nhf_preprocess.py
@@ -161,8 +161,7 @@ LAYERS_TO_READ: list[tuple[str, Optional[list[str]], bool]] = [
     ("virtual_nexus", None, True),
     (
         "lakes", 
-        [LAKE_ID_FIELD, "fp_id", "virtual_fp_id", "ifd", "LkArea", "LkMxE", "OrificeA",
-         "OrificeC", "OrificeE", "WeirC", "WeirE", "WeirL", "hy_id", "ref_fp_id"], 
+        LEVEL_POOL_PARAMS + ["hy_id", "ref_fp_id"], 
         True),
     ("gages", None, True),
     ("hydrolocations", None, True),


### PR DESCRIPTION
This PR resolves an oversight in my initial level pool implementation where lake features that did not have an fp_id associated with them would be dropped from routing.  In the updated functionality, any lake features that are associated with a virtual flowpath will lead to a level-pool routing scheme applied to that virtual flowpath.  

This is a notable break from the current conceptual model of NHF T-Route.  Under the current conceptual model, virtual flowpaths that are not associated with a flowpath have flow scaling applied and are not routed on.  To get the new functionality to work, we create temporary div and fp ids for any virtual flowpath that should have level pool routing applied. This promotion allows the vfps to pretend they are flowpaths during network pre-processing.  The vfp links are then removed from the network during waterbody pre-processing.


## Additions

- **_force_headwater_routing** This is where virtual flowpaths are setup to pretend to be flowpaths.  

## Removals

- **_build_div_weighting_matrix** Removed the block where divs where percentages didn't sum to 100 were scaled such that they did sum to 100.  Now, a warning is thrown when percents do not sum to 100.  
Divs that had vfps promoted were having the remaining vfp percentages scaled to 100, and the new div id assigned to the promoted vfp was replacing its percentage with 100.  This led to double counting of lateral flows for the divides where routing was applied to vfps.

## Changes

- Pulled LAKE_ID_FIELD out of the preprocess_waterbodies function to a global variable.
- Specified which fields should be loaded from the lakes layer
- **preprocess_waterbodies** indexed by virtual_fp_id instead of fp_id

## Testing

1. Hot Brook
2. Lake Creek
3. Great Lakes
4. Patuxent
5. (currently waiting on) run_conus_lakes.py
