### PR TITLE
Skip EWTS install if already present, update numpy version to match ngen

### DIFF
--- a/compiler_bmi.sh
+++ b/compiler_bmi.sh
@@ -3,7 +3,7 @@ set -e
 
 # This script is called during the ngen Dockerfile if the USE_EWTS
 # build argument is ON (or 1, True, or Yes). It enables/uses the
-# EWTS already intsalled in the ngen Dockerfile, then calls the
+# EWTS already installed in the ngen Dockerfile, then calls the
 # compiler.sh to install remaining dependencies
 
 export EWTS_PREFIX="${EWTS_PREFIX:-/opt/ewts}"
@@ -19,11 +19,6 @@ export LD_LIBRARY_PATH="${EWTS_PREFIX}/lib:${EWTS_PREFIX}/lib64:${LD_LIBRARY_PAT
 : "${EWTS_GIT_REF:=development}"
 : "${EWTS_GIT_URL:=https://github.com/${GH_ORG}/nwm-ewts.git}"
 : "${EWTS_PY_SUBDIR:=runtime/python/ewts}"
-
-echo "Installing EWTS from GitHub:"
-echo "  repo: ${EWTS_GIT_URL}"
-echo "  ref:  ${EWTS_GIT_REF}"
-echo "  dir:  ${EWTS_PY_SUBDIR}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -74,11 +69,31 @@ else
     echo "Using standard pip for EWTS installation"
 fi
 
-# Remove any old/stale ewts/troute_ewts from the environment to avoid shadowing
-$PIP_CMD uninstall -y ewts troute_ewts >/dev/null 2>&1 || true
 
-$PIP_CMD install \
-    "ewts @ git+${EWTS_GIT_URL}@${EWTS_GIT_REF}#subdirectory=${EWTS_PY_SUBDIR}"
+# When running within the ngen framework, the ngen Dockerfile may
+# have already installed the EWTS Python package. Reuse the existing
+# installation when available and only install EWTS when it is not
+# already present.
+if python - <<'PY'
+import ewts
+import ewts.logger
+print(f"Found existing EWTS Python package: {ewts.__file__}")
+print(f"Found existing EWTS logger module: {ewts.logger.__file__}")
+PY
+then
+    echo "Using existing EWTS Python package; skipping EWTS install"
+else
+    echo "EWTS Python package not found; installing from GitHub:"
+    echo "  repo: ${EWTS_GIT_URL}"
+    echo "  ref:  ${EWTS_GIT_REF}"
+    echo "  dir:  ${EWTS_PY_SUBDIR}"
+
+    # Remove any old/stale ewts/troute_ewts from the environment to avoid shadowing
+    $PIP_CMD uninstall -y ewts troute_ewts >/dev/null 2>&1 || true
+
+    $PIP_CMD install \
+        "ewts @ git+${EWTS_GIT_URL}@${EWTS_GIT_REF}#subdirectory=${EWTS_PY_SUBDIR}"
+fi
 
 # Now run the original standalone compiler script for everything else
 exec "${SCRIPT_DIR}/compiler.sh" "${PASSTHROUGH_ARGS[@]}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pip>=22.1.0
 setuptools>=70,<82
 wheel
-numpy>=2
+numpy==1.26.4
 Cython>3,!=3.0.4
 pandas<3
 xarray

--- a/src/troute-rnr/pyproject.toml
+++ b/src/troute-rnr/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.9"
 name = "troute_rnr"
 authors = [{ name = "Tadd Bindas", email = "Tadd.Bindas@rtx.com" }]
 dependencies = [
-    "numpy~=1.0",
+    "numpy==1.26.4",
     "pydantic>=2.12,<3",
     "pydantic-xml==2.16.0",
     "httpx==0.27.0",


### PR DESCRIPTION
When running within the ngen framework, the `ngen` `Dockerfile` may have already installed the EWTS Python package. Reuse the existing installation when available and only install EWTS when it is not already present.

## Changes

- Updated `compiler_bmi.sh` to skip installing EWTS if already installed
- Updated `numpy` to version `1.26.4` to match `ngen`,

## Testing

1. Tested with several formulations in ngen

