### PR TITLE
Fix bug on non-numeric lake_id values that led to nans in the channel parameter dataframe

### DIFF
--- a/src/troute-network/troute/NHF.py
+++ b/src/troute-network/troute/NHF.py
@@ -530,8 +530,10 @@ def _force_headwater_routing(
     )
 
     # Force routing on headwater vfps with waterbodies
+    numeric_lake_id = pd.to_numeric(waterbodies["lake_id"], errors="coerce")
+    _waterbodies = waterbodies.loc[numeric_lake_id.notna()].copy()
     _required_lp_fields = list(set(LEVEL_POOL_PARAMS).difference(["fp_id"]))
-    waterbody_vfps = waterbodies.dropna(subset=_required_lp_fields)["virtual_fp_id"].astype(int).values
+    waterbody_vfps = _waterbodies.dropna(subset=_required_lp_fields)["virtual_fp_id"].astype(int).values
     forced_vfps.extend(list(set(headwater_vfps).intersection(waterbody_vfps)))
 
     # In the future, could add more conditions here


### PR DESCRIPTION
## Background
This PR resolves a bug identified by @dylanlee in CONUS-scale routing on NHF 1.2.0.  The bug was introducing nan values into NHF.dataframe that crashed the MC kernel.  These nan values were introduced by the following mechanism.

1. lakes with non-numeric lake_id field but valid level pool parameters that are on a VFP but not an FP are assigned an artificial fp_id' in `force_headwater_routing`.  That artificial fp_id is added to the NHF.dataframe in network discretization, but because it is an artificial fp_id, the joined channel routing parameters are null.
2. In `clean_waterbodies`, lake_ids that are non-numeric lead to the lake dropping from the waterbodies dataset.
3. With no reference of the original waterbody in the waterbody dataframe, `refactor_reservoirs` does not know to remove the artificial fp_id row in NHF.dataframe. Thus the nan values are preserved and allowed to enter the kernel.

The lake leading to this bug was {3D0D96EC-4842-4951-B7CD-286E78D05610}

```bash
                                     lake_id         fp_id  virtual_fp_id    ifd  ...     OrificeE  WeirC        WeirE   WeirL
328   {0E5D8D7E-63B3-44DD-9594-F4340C9BEA94}  1.264925e+15   1.264925e+15  0.899  ...  1629.505493    0.4  1629.505493  1130.0
448   {D72DEEEA-EBED-4367-8235-E85C2698633C}  1.265020e+15   1.265020e+15  0.899  ...  1744.449951    0.4  1744.449951    20.0
883   {3D0D96EC-4842-4951-B7CD-286E78D05610}           NaN   1.275522e+15  0.899  ...   361.008453    0.4   361.008453   375.0
954   {F4F18D4F-E035-4C06-87DF-F75B41285652}  1.272484e+15   1.272484e+15  0.899  ...   156.000000    0.4   156.000000  4200.0
1529  {E3AB6708-E92B-478D-A128-7426BF149221}  1.271217e+15   1.271217e+15  0.899  ...   119.684830    0.4   119.684830    10.0
1745  {FA69E737-FD23-4C95-922E-9241D943DCC3}  1.282566e+15   1.282566e+15  0.899  ...   170.453171    0.4   170.453171  2600.0

[6 rows x 12 columns]
```

## Fix:
Prevent forced routing on waterbodies with lake_ids that will be dropped in `clean_waterbodies`.

Generally, I am dissatisfied with this approach. We need to assign artificial fp_ids to vfps with lakes before network preprocessing so that they get into the lateral flow weighting matrix. But some of those lakes will then get dropped in `clean_waterbodies`. Maintaining parity between the dropping of lakes in `force_headwater_routing` and `clean_waterbodies` is clunky.

Earlier, I was tempted to move `clean_waterbodies` out of `preprocess_waterbodies` and into NHF __init__, but I think that may be the correct approach.

This commit is stable and passing run_conus_lakes.py



