### PR TITLE
fix: _refactor_reservoirs now skips empty synthetic waterbody reach DF

### DIFF
--- a/src/troute-network/troute/nhf_preprocess.py
+++ b/src/troute-network/troute/nhf_preprocess.py
@@ -855,10 +855,11 @@ class NHFPreprocessMixin:
         wb_index = self.waterbody_dataframe.index.tolist()
         self.waterbody_connections = dict(zip(wb_index, wb_index))
 
-        row_df = pd.DataFrame(df_rows, index=index_vals)
-        row_df.index.name = self.dataframe.index.name
-        row_df = row_df.astype(self.dataframe.dtypes.to_dict())
-        self.dataframe = pd.concat([self.dataframe, row_df])
+        if df_rows:
+            row_df = pd.DataFrame(df_rows, index=index_vals)
+            row_df.index.name = self.dataframe.index.name
+            row_df = row_df.astype(self.dataframe.dtypes.to_dict())
+            self.dataframe = pd.concat([self.dataframe, row_df])
 
 
     def preprocess_data_assimilation(


### PR DESCRIPTION
When all waterbodies are dropped during preprocessing (e.g., missing LkArea), _refactor_reservoirs still attempted to cast an empty DataFrame against self.dataframe.dtypes. The fix adds a guard so the empty case is handled gracefully. Routing proceeds with lakes demoted to plain MC channels.