### PR TITLE
Remove Subnetwork from Save State (NGWPC-11208)

### DIFF
--- a/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
+++ b/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
@@ -270,14 +270,8 @@ class Model:
 
     def create_state(self):
         """Create a dictionary of data that can be serialized using `pickle.dumps`."""
-        # save current subnetwork and convert defaultdicts to dicts
-        subnetwork = list(self._subnetwork)
-        for i, value in enumerate(subnetwork):
-            if isinstance(value, dict):
-                subnetwork[i] = dict(value)
         return {
             "time": self._time,
-            "subnetwork": subnetwork,
             # updated data stored on AbstractNetwork
             "q0": self._network._q0,
             "t0": self._network._t0,
@@ -291,7 +285,6 @@ class Model:
 
     def load_state(self, data: dict):
         self._time = data["time"]
-        self._subnetwork = data["subnetwork"]
         self._network._q0 = data["q0"]
         self._network._t0 = data["t0"]
         self._data_assimilation._last_obs_df = data["last_obs"]


### PR DESCRIPTION
The structure of the subnetworks was redesigned to be more usable than a list of dictionaries. Rather than requiring these large structures to be serializable, removing them from serialization is an easier option that slightly increases the run time for a loaded state relative to storing a potentially large amount of data.

## Additions

-

## Removals

- Subnetwork results are excluded from save state data.

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
