### PR TITLE
Output temporary file handling and merging

### DIFF
--- a/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
+++ b/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
@@ -503,6 +503,10 @@ class Model:
                         err = f"Cannot merge output formats other than .nc, .csv, or .pkl. Format provided in the config file: {stream_type}"
                         LOG.error(err)
                         raise RuntimeError(err)
+
+                    original_mode = files[0].stat().st_mode
+                    Path(combo_path).chmod(original_mode)
+
                     for f in files:
                         f.unlink()
                     Path(combo_path).rename(out_path)
@@ -535,6 +539,10 @@ class Model:
                         compat="override"
                     ) as ds:
                         ds.load().to_netcdf(combo_path)
+
+                    original_mode = files[0].stat().st_mode
+                    Path(combo_path).chmod(original_mode)
+
                     for f in files:
                         f.unlink()
                     Path(combo_path).rename(out_path)

--- a/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
+++ b/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
@@ -486,7 +486,7 @@ class Model:
                             coords="minimal",
                             compat="override"
                         ) as ds:
-                            ds.to_netcdf(combo_path)
+                            ds.load().to_netcdf(combo_path)
                     elif stream_type == ".csv":
                         df = pd.concat(
                             (pd.read_csv(f) for f in files),
@@ -511,7 +511,7 @@ class Model:
                     raise
                 self._timings["output_time"] = time.time() - start_time
         wbdy_dir = self.output_parameters.get("lakeout_output", None)
-        if isinstance(wbdy_dir, str):
+        if isinstance(wbdy_dir, Path):
             files = sorted(
                 Path(wbdy_dir).glob("troute_lakeout_*.nc"),
                 key=lambda f: f.stem
@@ -534,7 +534,7 @@ class Model:
                         coords="minimal",
                         compat="override"
                     ) as ds:
-                        ds.to_netcdf(combo_path)
+                        ds.load().to_netcdf(combo_path)
                     for f in files:
                         f.unlink()
                     Path(combo_path).rename(out_path)

--- a/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
+++ b/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
@@ -518,19 +518,29 @@ class Model:
             )
             if len(files) > 1:
                 start_time = time.time()
-                orig = files[0]
-                files[0] = orig.rename(orig.with_stem('_' + orig.stem))
-                with xr.open_mfdataset(
-                    files,
-                    concat_dim="time",
-                    combine="nested",
-                    data_vars="minimal",
-                    coords="minimal",
-                    compat="override"
-                ) as ds:
-                    ds.to_netcdf(orig)
-                for f in files:
-                    f.unlink()
+                out_path = str(files[0].resolve())
+                with NamedTemporaryFile(
+                    suffix=stream_type,
+                    dir=stream_dir,
+                    delete=False
+                ) as tmp:
+                    combo_path = tmp.name
+                try:
+                    with xr.open_mfdataset(
+                        files,
+                        concat_dim="time",
+                        combine="nested",
+                        data_vars="minimal",
+                        coords="minimal",
+                        compat="override"
+                    ) as ds:
+                        ds.to_netcdf(combo_path)
+                    for f in files:
+                        f.unlink()
+                    Path(combo_path).rename(out_path)
+                except Exception:
+                    Path(combo_path).unlink(missing_ok=True)
+                    raise
                 self._timings["output_time"] = time.time() - start_time
 
     def _is_nhf(self):

--- a/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
+++ b/src/troute-bmi/src/troute_nwm_bmi/troute_model.py
@@ -1,6 +1,7 @@
 """Basic Model Interface backing model for NGEN t-route."""
 from __future__ import annotations
 import math
+from tempfile import NamedTemporaryFile
 import psutil
 import time
 import typing
@@ -468,36 +469,46 @@ class Model:
             )
             if len(files) > 1:
                 start_time = time.time()
-                orig = files[0]
-                files[0] = orig.rename(orig.with_stem('_' + orig.stem))
-                if stream_type == ".nc":
-                    with xr.open_mfdataset(
-                        files,
-                        concat_dim="time",
-                        combine="nested",
-                        data_vars="minimal",
-                        coords="minimal",
-                        compat="override"
-                    ) as ds:
-                        ds.to_netcdf(orig)
-                elif stream_type == ".csv":
-                    df = pd.concat(
-                        (pd.read_csv(f) for f in files),
-                        ignore_index=True
-                    )
-                    df.to_csv(orig, index=False)
-                elif stream_type == ".pkl":
-                    df = pd.concat(
-                        (pd.read_pickle(f) for f in files),
-                        ignore_index=False
-                    )
-                    df.to_pickle(orig)
-                else:
-                    err = f"Cannot merge output formats other than .nc, .csv, or .pkl. Format provided in the config file: {stream_type}"
-                    LOG.error(err)
-                    raise RuntimeError(err)
-                for f in files:
-                    f.unlink()
+                out_path = str(files[0].resolve())
+                with NamedTemporaryFile(
+                    suffix=stream_type,
+                    dir=stream_dir,
+                    delete=False
+                ) as tmp:
+                    combo_path = tmp.name
+                try:
+                    if stream_type == ".nc":
+                        with xr.open_mfdataset(
+                            files,
+                            concat_dim="time",
+                            combine="nested",
+                            data_vars="minimal",
+                            coords="minimal",
+                            compat="override"
+                        ) as ds:
+                            ds.to_netcdf(combo_path)
+                    elif stream_type == ".csv":
+                        df = pd.concat(
+                            (pd.read_csv(f) for f in files),
+                            ignore_index=True
+                        )
+                        df.to_csv(combo_path, index=False)
+                    elif stream_type == ".pkl":
+                        df = pd.concat(
+                            (pd.read_pickle(f) for f in files),
+                            ignore_index=False
+                        )
+                        df.to_pickle(combo_path)
+                    else:
+                        err = f"Cannot merge output formats other than .nc, .csv, or .pkl. Format provided in the config file: {stream_type}"
+                        LOG.error(err)
+                        raise RuntimeError(err)
+                    for f in files:
+                        f.unlink()
+                    Path(combo_path).rename(out_path)
+                except Exception:
+                    Path(combo_path).unlink(missing_ok=True)
+                    raise
                 self._timings["output_time"] = time.time() - start_time
         wbdy_dir = self.output_parameters.get("lakeout_output", None)
         if isinstance(wbdy_dir, str):

--- a/test/nhf/utils/run_bmi.py
+++ b/test/nhf/utils/run_bmi.py
@@ -34,7 +34,7 @@ def run_bmi(config_path: str):
 
     # Read first file to get IDs (all files share the same feature_id index)
     first_df = pd.read_csv(forcing_files[0]).set_index("feature_id")
-    feature_ids = np.array(first_df.index, dtype=np.intc)
+    feature_ids = np.array(first_df.index, dtype=np.int64)
 
     # Set the IDs (constant across all timesteps)
     model.set_value("catchment_water_source__id", feature_ids)


### PR DESCRIPTION
Fixes bug in merging multi-file troute outputs, as previously the merge wrote over the original file so a failure could cause data loss. Also updates permission handling on resulting merged troute outputs.

## Additions

- Write merged output to a temp file first, then rename it only after success
- Preserve original file permissions on the merged output
- Delete temp file if merge fails

## Removals

- Old in-place rename/overwrite output handling

## Changes

-

## Testing

1. Verified successful merge of multiple troute output/lakeout files in an integrated ngen VPU run using the RTE

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
